### PR TITLE
Implement question wrapper

### DIFF
--- a/src/components/plugin-app.tsx
+++ b/src/components/plugin-app.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import WindowShade from "./window-shade";
+import QuestionWrapper from "./question-wrapper";
 
 interface IProps {
   PluginAPI: any;
@@ -8,6 +9,8 @@ interface IProps {
   content?: string;
   label?: string;
   icon?: string;
+  wrappedEmbeddableDiv?: HTMLDivElement;
+  wrappedEmbeddableContext?: object;
 }
 interface IState {}
 
@@ -32,6 +35,7 @@ export default class PluginApp extends React.Component<IProps, IState> {
     const { type } = this.props;
     switch (type) {
       case "windowShade": return this.renderWindowShade();
+      case "questionWrapper": return this.renderQuestionWrapper();
       case "sideTip": return this.renderSidebarTip();
     }
   }
@@ -40,6 +44,23 @@ export default class PluginApp extends React.Component<IProps, IState> {
     return (
       <div>
         <WindowShade content={this.props.content} />
+      </div>
+    );
+  }
+
+  public renderQuestionWrapper() {
+    const { wrappedEmbeddableDiv, wrappedEmbeddableContext } = this.props;
+    if (!wrappedEmbeddableDiv || !wrappedEmbeddableContext) {
+      // tslint:disable-next-line:no-console
+      console.warn("Cannot render question wrapper - missing wrapped question reference");
+      return null;
+    }
+    return (
+      <div>
+        <QuestionWrapper
+          wrappedEmbeddableDiv={wrappedEmbeddableDiv}
+          wrappedEmbeddableContext={wrappedEmbeddableContext}
+        />
       </div>
     );
   }

--- a/src/components/plugin-app.tsx
+++ b/src/components/plugin-app.tsx
@@ -2,16 +2,15 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import WindowShade from "./window-shade";
 import QuestionWrapper from "./question-wrapper";
+import { IAuthoredState } from "../types";
 
 interface IProps {
   PluginAPI: any;
-  type: string;
-  content?: string;
-  label?: string;
-  icon?: string;
+  authoredState: IAuthoredState;
   wrappedEmbeddableDiv?: HTMLDivElement;
   wrappedEmbeddableContext?: object;
 }
+
 interface IState {}
 
 interface ISidebarController {
@@ -25,31 +24,37 @@ export default class PluginApp extends React.Component<IProps, IState> {
 
   constructor(props: IProps) {
     super(props);
-    const { type } = this.props;
+    const { type } = this.props.authoredState;
     if (type === "sideTip") {
       this.addSidebar();
     }
   }
 
   public render() {
-    const { type } = this.props;
+    const { type } = this.props.authoredState;
     switch (type) {
       case "windowShade": return this.renderWindowShade();
       case "questionWrapper": return this.renderQuestionWrapper();
       case "sideTip": return this.renderSidebarTip();
     }
+    return null;
   }
 
   public renderWindowShade() {
+    const { windowShade } = this.props.authoredState;
+    if (!windowShade) {
+      return null;
+    }
     return (
       <div>
-        <WindowShade content={this.props.content} />
+        <WindowShade authoredState={windowShade} />
       </div>
     );
   }
 
   public renderQuestionWrapper() {
-    const { wrappedEmbeddableDiv, wrappedEmbeddableContext } = this.props;
+    const { wrappedEmbeddableDiv, wrappedEmbeddableContext, authoredState } = this.props;
+    const { questionWrapper } = authoredState;
     if (!wrappedEmbeddableDiv || !wrappedEmbeddableContext) {
       // tslint:disable-next-line:no-console
       console.warn("Cannot render question wrapper - missing wrapped question reference");
@@ -58,6 +63,7 @@ export default class PluginApp extends React.Component<IProps, IState> {
     return (
       <div>
         <QuestionWrapper
+          authoredState={questionWrapper || {}}
           wrappedEmbeddableDiv={wrappedEmbeddableDiv}
           wrappedEmbeddableContext={wrappedEmbeddableContext}
         />

--- a/src/components/question-wrapper.sass
+++ b/src/components/question-wrapper.sass
@@ -1,0 +1,66 @@
+.questionWrapper
+  .headers
+    height: 50px
+    overflow: hidden
+
+    div
+      font-size: 18px
+      color: white
+      border-left: 3px solid
+      border-top: 3px solid
+      border-right: 3px solid
+      border-top-left-radius: 24px
+      border-top-right-radius: 24px
+      display: inline-block
+      height: 50px
+      margin-right: 4px
+      text-align: center
+      padding: 10px 12px
+      cursor: pointer
+      vertical-align: top
+      margin-top: 15px
+      transition: margin-top 250ms
+      &:hover
+        margin-top: 0 !important
+
+    .correct
+      background: #2FE450
+      border-color: #128325
+    .distractors
+      background: #FC1B1B
+      border-color: #A20005
+    .teacherTip
+      background: #1A97FF
+      border-color: #094F98
+
+
+  .wrappedContent
+    border: 3px solid #7A7A7A
+    border-bottom-left-radius: 17px
+    border-bottom-right-radius: 17px
+    padding: 1px
+    position: relative
+
+    .overlay
+      position: absolute
+      width: 100%
+      height: 100%
+      top: 0
+      left: 0
+      z-index: 1000
+      border-radius: inherit
+
+      &.correctOverlay
+        background: #2FE450
+        opacity: 0.12
+
+      &.distractorsOverlay
+        background: #FC1B1B
+        opacity: 0.12
+
+      &.teacherTipOverlay
+        background: #A6D5FF
+        opacity: 0.12
+
+  .footer
+    padding: 10px

--- a/src/components/question-wrapper.sass
+++ b/src/components/question-wrapper.sass
@@ -2,9 +2,14 @@
   .headers
     height: 50px
     overflow: hidden
+    display: flex
 
     div
+      max-width: 350px
+      flex: 1
+      white-space: nowrap
       font-size: 18px
+      font-weight: bold
       color: white
       border-left: 3px solid
       border-top: 3px solid
@@ -13,17 +18,19 @@
       border-top-right-radius: 24px
       display: inline-block
       height: 50px
-      margin-right: 4px
-      text-align: center
+      text-align: left
       padding: 10px 12px
       cursor: pointer
       vertical-align: top
       margin-top: 15px
       transition: margin-top 250ms
+      margin-right: 4px
+      &:last-child
+        margin-right: 0
       &:hover
         margin-top: 0 !important
 
-    .correct
+    .correct, .exemplar
       background: #2FE450
       border-color: #128325
     .distractors
@@ -32,7 +39,6 @@
     .teacherTip
       background: #1A97FF
       border-color: #094F98
-
 
   .wrappedContent
     border: 3px solid #7A7A7A
@@ -43,6 +49,7 @@
 
     .overlay
       position: absolute
+      pointer-events: none
       width: 100%
       height: 100%
       top: 0
@@ -50,7 +57,7 @@
       z-index: 1000
       border-radius: inherit
 
-      &.correctOverlay
+      &.correctOverlay, &.exemplarOverlay
         background: #2FE450
         opacity: 0.12
 

--- a/src/components/question-wrapper.tsx
+++ b/src/components/question-wrapper.tsx
@@ -1,0 +1,126 @@
+import * as React from "react";
+import * as css from "./question-wrapper.sass";
+
+type tab = "Correct" | "Distractors" | "TeacherTip";
+
+interface IProps {
+  wrappedEmbeddableDiv: HTMLDivElement;
+  wrappedEmbeddableContext: any;
+}
+interface IState {
+  activeTab: tab | null;
+}
+
+export default class QuestionWrapper extends React.Component<IProps, IState> {
+  public state: IState = {
+    activeTab: null
+  };
+
+  private wrappedEmbeddableDivContainer = React.createRef<HTMLDivElement>();
+  private answerInputs: NodeListOf<HTMLInputElement>;
+
+  public componentDidMount() {
+    const { wrappedEmbeddableDiv } = this.props;
+    if (!wrappedEmbeddableDiv) {
+      return;
+    }
+    const containerNode = this.wrappedEmbeddableDivContainer.current!;
+    containerNode.appendChild(wrappedEmbeddableDiv);
+
+    // Find answer inputs. Used later.
+    this.answerInputs = this.findInputsInWrappedQuestion();
+  }
+
+  public render() {
+    const { activeTab } = this.state;
+    const { wrappedEmbeddableContext } = this.props;
+    const choices = wrappedEmbeddableContext.choices;
+
+    let overlayClass = css.overlay;
+    if (activeTab === "Correct") {
+      overlayClass += " " + css.correctOverlay;
+    } else if (activeTab === "Distractors") {
+      overlayClass += " " + css.distractorsOverlay;
+    } else if (activeTab === "TeacherTip") {
+      overlayClass += " " + css.teacherTipOverlay;
+    }
+    return (
+      <div className={css.questionWrapper}>
+        <div className={css.headers}>
+          <div className={css.correct} onClick={this.toggleCorrect}>Correct</div>
+          <div className={css.distractors} onClick={this.toggleDistractors}>Distractors</div>
+          <div className={css.teacherTip} onClick={this.toggleTeacherTip}>Teacher Tip</div>
+        </div>
+        <div className={css.wrappedContent}>
+          <div ref={this.wrappedEmbeddableDivContainer} />
+          <div className={overlayClass} />
+          {
+            activeTab === "Correct" && choices.map((c: any, idx: number) =>
+              c.is_correct ?
+                <div
+                  key={idx}
+                  style={{
+                    position: "absolute",
+                    top: this.answerInputs[idx].offsetTop,
+                    left: this.answerInputs[idx].offsetLeft}}
+                >
+                  ✔
+                </div>
+                :
+                null
+            )
+          }
+          {
+            activeTab === "Distractors" && choices.map((c: any, idx: number) =>
+              !c.is_correct ?
+                <div
+                  key={idx}
+                  style={{
+                    position: "absolute",
+                    top: this.answerInputs[idx].offsetTop,
+                    left: this.answerInputs[idx].offsetLeft}}
+                >
+                  X
+                </div>
+                :
+                null
+            )
+          }
+          {
+            activeTab !== null &&
+            <div className={css.footer}>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean eleifend finibus lorem, commodo mollis
+              mauris rutrum id. Curabitur maximus libero ut volutpat fermentum. Class aptent taciti sociosqu ad litora
+              torquent per conubia nostra, per inceptos himenaeos. Cras in nunc accumsan, efficitur ligula sed, commodo
+              velit. Sed pellentesque euismod arcu eget ultrices. Curabitur blandit consectetur interdum. Proin nec
+              neque quam congue suscipit in ut augue. Sed venenatis ac dui eu mollis. Phasellus vitae augue at tortor
+              porttitor sodales sit amet sit amet velit. Nulla vel turpis iaculis, vestibulum quam nec, mollis diam.
+            </div>
+          }
+        </div>
+      </div>
+    );
+  }
+
+  private findInputsInWrappedQuestion() {
+    const { wrappedEmbeddableContext, wrappedEmbeddableDiv } = this.props;
+    const inputType = wrappedEmbeddableContext.multi_answer ? "checkbox" : "radio";
+    // There's one assumption about LARA Multiple Choice question.
+    return wrappedEmbeddableDiv.querySelectorAll(`input[type="${inputType}"]`) as NodeListOf<HTMLInputElement>;
+  }
+
+  private toggleCorrect = () => {
+    const { activeTab } = this.state;
+    this.setState({ activeTab: activeTab === "Correct" ? null : "Correct" });
+  }
+
+  private toggleDistractors = () => {
+    const { activeTab } = this.state;
+    this.setState({ activeTab: activeTab === "Distractors" ? null : "Distractors" });
+  }
+
+  private toggleTeacherTip = () => {
+    const { activeTab } = this.state;
+    this.setState({ activeTab: activeTab === "TeacherTip" ? null : "TeacherTip" });
+  }
+}

--- a/src/components/window-shade.sass
+++ b/src/components/window-shade.sass
@@ -9,7 +9,7 @@
   border-radius: 25px
   border: #878706 solid 3px
   background-color: #FAFA15
-  display: flex;
+  display: flex
   flex-direction: column
   justify-content: center
   text-align: center
@@ -26,9 +26,9 @@
   border: #878706 solid 3px
   border-radius: 0px 0px 25px 25px
   padding: 30px
-  padding-top: 45px;
-  padding-bottom: 28px;
+  padding-top: 45px
+  padding-bottom: 28px
 
 .windowShadeContentHide
-  height: 0px
+  height: 0
   overflow: hidden

--- a/src/components/window-shade.test.tsx
+++ b/src/components/window-shade.test.tsx
@@ -4,7 +4,7 @@ import { shallow } from "enzyme";
 
 describe("WindowShade component", () => {
   it("renders Hello World", () => {
-    const wrapper = shallow(<WindowShade/>);
-    expect(wrapper.text()).toEqual("Hello World");
+    const wrapper = shallow(<WindowShade authoredState={{content: "Hello World"}}/>);
+    expect(wrapper.text()).toEqual(expect.stringContaining("Hello World"));
   });
 });

--- a/src/components/window-shade.tsx
+++ b/src/components/window-shade.tsx
@@ -1,16 +1,10 @@
 import * as React from "react";
 
 import * as css from "./window-shade.sass";
-
-interface IWindowShadeType {
-  label: string;
-  icon: string;
-}
+import { IAuthoredWindowShade } from "../types";
 
 interface IProps {
-  label?: string;
-  icon?: string;
-  content?: string;
+  authoredState: IAuthoredWindowShade;
 }
 interface IState {
   open: boolean;
@@ -23,6 +17,8 @@ export default class WindowShade extends React.Component<IProps, IState> {
 
   public render() {
     const { open } = this.state;
+    const { content } = this.props.authoredState;
+
     const toggle = () => {
       this.setState({open: !open});
     };
@@ -32,7 +28,7 @@ export default class WindowShade extends React.Component<IProps, IState> {
           Theory &amp; Background
         </div>
         <div className={open ? css.windowShadeContentShow : css.windowShadeContentHide }>
-          {this.props.content}
+          {content}
         </div>
       </div>
     );

--- a/src/demo.tsx
+++ b/src/demo.tsx
@@ -3,10 +3,7 @@ import * as ReactDOM from "react-dom";
 import WindowShade from "./components/window-shade";
 
 const authoredState = {
-  type: "windowShade",
-  windowShadeType: {label: "label", icon: "icon"},
-  content:
-`This page is the first of a series of model and data-based case studies
+  content: `This page is the first of a series of model and data-based case studies
 embedded in the GEODE module. Students will be asked to make explanations
 for how particular features on Earth were formed. (In this case, they are
 asked to explain how the Himalayan Mountains formed.) Students are provided
@@ -18,9 +15,9 @@ up a model to explain how the region’s features were formed. Finally,
 students are asked to make an argument about how well their model explains
 the formation of the particular Earth features.
 `
-
 };
+
 ReactDOM.render(
-  <WindowShade {...authoredState} />,
+  <WindowShade authoredState={authoredState} />,
   document.getElementById("window-shade")
 );

--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -7,6 +7,8 @@ interface IExternalScriptContext {
   authoredState: string;
   learnerState: string;
   pluginId: string;
+  wrappedEmbeddableDiv?: any;
+  wrappedEmbeddableContext?: any;
 }
 
 let PluginAPI: any;
@@ -43,6 +45,8 @@ export class TeacherEditionTipsPlugin {
         <PluginApp
           content={authoredState.content || "Hello World"}
           type={authoredState.type || "windowShade"}
+          wrappedEmbeddableDiv={this.context.wrappedEmbeddableDiv}
+          wrappedEmbeddableContext={this.context.wrappedEmbeddableContext}
           PluginAPI={PluginAPI}
         />,
         this.context.div);

--- a/src/plugin.tsx
+++ b/src/plugin.tsx
@@ -43,8 +43,7 @@ export class TeacherEditionTipsPlugin {
     if (PluginAPI.isTeacherEdition()) {
       this.pluginAppComponent = ReactDOM.render(
         <PluginApp
-          content={authoredState.content || "Hello World"}
-          type={authoredState.type || "windowShade"}
+          authoredState={authoredState}
           wrappedEmbeddableDiv={this.context.wrappedEmbeddableDiv}
           wrappedEmbeddableContext={this.context.wrappedEmbeddableContext}
           PluginAPI={PluginAPI}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,16 @@
+export interface IAuthoredState {
+  type: string;
+  windowShade?: IAuthoredWindowShade;
+  questionWrapper?: IAuthoredQuestionWrapper;
+}
+
+export interface IAuthoredWindowShade {
+  content: string;
+}
+
+export interface IAuthoredQuestionWrapper {
+  correctExplanation?: string;
+  distractorsExplanation?: string;
+  teacherTip?: string;
+  exemplar?: string;
+}


### PR DESCRIPTION
First, some examples:
<img width="449" alt="screenshot 2018-11-06 at 15 11 44" src="https://user-images.githubusercontent.com/767857/48069702-5cbde580-e1d6-11e8-8593-f295a9f89a11.png">
<img width="481" alt="screenshot 2018-11-06 at 15 11 39" src="https://user-images.githubusercontent.com/767857/48069707-5e87a900-e1d6-11e8-92c5-45acc0be7a07.png">
Configuration:
```json
{
 "type": "questionWrapper",
  "questionWrapper": {
    "distractorsExplanation": "distractors",
    "teacherTip": "teacher tip"
  }
}
```

It can wrap any question you want. Configuration is as minimal as possible. "Correct" and "Distractors" tab will show up automatically if question is a multiple choice with at least one question marked as 
correct. Other tabs require explanation to be provided obviously. 

Once we have icons and markdown available, I'll continue working on styles and add markdown support.

This covers pretty much almost all the cases we need:
- multiple choice correct, distractors, and teacher tip tabs
- open response examplar and teacher tip tabs

Later, we can implement interactive teacher tip using the same plugin, just change header and border styles. Image overlay will be very simple and actually it will be possible to use it even with multiple choice question (if anyone ever wants that).

@knowuh, @DALove1025, I've implemented a bit different handling of the authoring state. I mentioned that on Slack, here's an example. You can take a look at `src/types.ts` file. 

It depends on new LARA features that are not available yet. I'm waiting for @knowuh's embeddable plugins work to be cleaned up and merged, as LARA my work depends on it.