### PR TITLE
161789379 cleanup styling

### DIFF
--- a/src/components/_color-themes.sass
+++ b/src/components/_color-themes.sass
@@ -35,7 +35,7 @@ $yellowBackgroundColorOnHover: $brightYellow
 $yellowIconColor: $paleYellow
 $yellowIconBackgroundColor: $mediumYellow
 $yellowBorderColor: $deepYellow
-$yellowContentBackground: $paleYellow
+$yellowContentBackgroundColor: $paleYellow
 $yellowMediaIconColor: $mediumYellow
 $yellowHilitText: $deepYellow
 
@@ -48,6 +48,7 @@ $blueBackgroundColorOnHover: $brightBlue
 $blueIconColor: $paleBlue
 $blueIconBackgroundColor: $mediumBlue
 $blueBorderColor: $deepBlue
+$blueContentBackgroundColor: $paleBlue
 $blueMediaIconColor: $mediumBlue
 $blueHilitText: $mediumBlue
 
@@ -60,6 +61,7 @@ $orangeBackgroundColorOnHover: $brightOrange
 $orangeIconColor: $paleOrange
 $orangeIconBackgroundColor: $mediumOrange
 $orangeBorderColor: $deepOrange
+$orangeContentBackgroundColor: $paleOrange
 $orangeMediaIconColor: $mediumOrange
 $orangeHilitText: $darkOrange
 
@@ -72,5 +74,6 @@ $purpleBackgroundColorOnHover: $brightPurple
 $purpleIconColor: $palePurple
 $purpleIconBackgroundColor: $mediumPurple
 $purpleBorderColor: $darkPurple
+$purpleContentBackgroundColor: $palePurple
 $purpleMediaIconColor: $mediumPurple
 $purpleHilitText: $deepPurple

--- a/src/components/_color-themes.sass
+++ b/src/components/_color-themes.sass
@@ -10,70 +10,94 @@
 // | diggingDeeper       | purple |
 //
 // Orthognal to each of these color sets based on the window shade type, each
-// one has a set stylistic properties used in it's rendering:
+// one has a set stylistic properties that are used in it's rendering:
 //
-//  * textColor, textColorOnHover: for the title text, in the button, itself.
+//  * ButtonTextColor, ButtonTextHoverColor, ButtonBackgroundColor,
+//    ButtonBackgroundHoverColor: colors behind the button's title-text, shown
+//    inside the WindowShadeButton, itself. The background colors are also used
+//    behind the media icon, if present in the button.
 //
-//  * backgroundColor, backgroundColorOnHover: background behind the title
-//    text of the button, and the media icon, if one is present.
+//  * BorderColor: the color used to draw the border around the button and the
+//    around the content, when it's displayed.
 //
-//  * borderColor: border color draw around the button, and the content when it
-//    is displayed.
+//  * ContentTextColor, ContentTextAccentColor, ContentBackgroundColor: the
+//    normal-text, emphasiazed-text, and background colors used for the text
+//    content displayed in an "open" WindowShadedContent component.
 //
-//  * iconColor, iconBackgroundColor: how this will actually work is yet to be
-//    determeind.
+//  * RearIconColor, FrontIconColor, MediaIconColor: the svg "fill" colors used
+//    to render the icons of the LeftEndCap and RightEndCap components.
 //
-//  * mediaIconColor: the color used to render the media icon, if one is
-//    present in the window shade button.
+//  * IconBackgroundColor: the background color behind the combination of the
+//    rear and front icons in the LeftEndCap component.
 
-// The "yellow" theme, used for theoryAndBackground
+// The "yellow" theme; used for theoryAndBackground
 
-$yellowTextColor: $darkYellow
-$yellowTextColorOnHover: $darkYellow
-$yellowBackgroundColor: $fullYellow
-$yellowBackgroundColorOnHover: $brightYellow
-$yellowIconColor: $paleYellow
-$yellowIconBackgroundColor: $mediumYellow
+$yellowButtonTextColor: $darkYellow
+$yellowButtonTextHoverColor: $darkYellow
+$yellowButtonBackgroundColor: $fullYellow
+$yellowButtonBackgroundHoverColor: $brightYellow
+
 $yellowBorderColor: $deepYellow
-$yellowContentBackgroundColor: $paleYellow
+
+$yellowContentTextColor: $textBlack
+$yellowContentTextAccentColor: $deepYellow
+$yellowContentBackgroundColor: $paleYellow  
+
+$yellowRearIconColor: $lightYellow
+$yellowFrontIconColor: $paleYellow
 $yellowMediaIconColor: $mediumYellow
-$yellowHilitText: $deepYellow
+$yellowIconBackgroundColor: $mediumYellow
 
-// The "blue" theme, used for teacherTips & teacherTipOverlay
+// The "blue" theme; used for teacherTips & teacherTipOverlay
 
-$blueTextColor: $paleBlue
-$blueTextColorOnHover: $darkBlue
-$blueBackgroundColor: $fullBlue
-$blueBackgroundColorOnHover: $brightBlue
-$blueIconColor: $paleBlue
-$blueIconBackgroundColor: $mediumBlue
+$blueButtonTextColor: $paleBlue
+$blueButtonTextHoverColor: $darkBlue
+$blueButtonBackgroundColor: $fullBlue
+$blueButtonBackgroundHoverColor: $brightBlue
+
 $blueBorderColor: $deepBlue
+
+$blueContentTextColor: $textBlack
+$blueContentTextAccentColor: $mediumBlue
 $blueContentBackgroundColor: $paleBlue
+
+$blueRearIconColor: $brightBlue
+$blueFrontIconColor: $paleBlue
 $blueMediaIconColor: $mediumBlue
-$blueHilitText: $mediumBlue
+$blueIconBackgroundColor: $mediumBlue  
 
-// The "orange" theme, used for discussionPoints
+// The "orange" theme; used for discussionPoints
 
-$orangeTextColor: $paleOrange
-$orangeTextColorOnHover: $darkOrange
-$orangeBackgroundColor: $fullOrange
-$orangeBackgroundColorOnHover: $brightOrange
-$orangeIconColor: $paleOrange
-$orangeIconBackgroundColor: $mediumOrange
+$orangeButtonTextColor: $paleOrange
+$orangeButtonTextHoverColor: $darkOrange
+$orangeButtonBackgroundColor: $fullOrange
+$orangeButtonBackgroundHoverColor: $brightOrange
+
 $orangeBorderColor: $deepOrange
+
+$orangeContentTextColor: $textBlack
+$orangeContentTextAccentColor: $darkOrange
 $orangeContentBackgroundColor: $paleOrange
+
+$orangeRearIconColor: $fadedOrange
+$orangeFrontIconColor: $paleOrange
 $orangeMediaIconColor: $mediumOrange
-$orangeHilitText: $darkOrange
+$orangeIconBackgroundColor: $mediumOrange
 
-// The "purple" theme, used for diggingDeeper
+// The "purple" theme; used for diggingDeeper
 
-$purpleTextColor: $palePurple
-$purpleTextColorOnHover: $darkPurple
-$purpleBackgroundColor: $fullPurple
-$purpleBackgroundColorOnHover: $brightPurple
-$purpleIconColor: $palePurple
-$purpleIconBackgroundColor: $mediumPurple
-$purpleBorderColor: $darkPurple
+$purpleButtonTextColor: $palePurple
+$purpleButtonTextHoverColor: $darkPurple
+$purpleButtonBackgroundColor: $fullPurple
+$purpleButtonBackgroundHoverColor: $brightPurple
+
+$purpleBorderColor: $deepPurple
+
+$purpleContentTextColor: $textBlack
+$purpleContentTextAccentColor: $deepPurple
 $purpleContentBackgroundColor: $palePurple
+
+$purpleRearIconColor: $somePurple
+$purpleFrontIconColor: $palePurple
 $purpleMediaIconColor: $mediumPurple
-$purpleHilitText: $deepPurple
+$purpleIconBackgroundColor: $mediumPurple

--- a/src/components/_colors.sass
+++ b/src/components/_colors.sass
@@ -1,10 +1,14 @@
-// There are several color pallets used for various purposes, where a particular
-// pallet is applied to the UI based on the type of the widget being displayed.
-// For example, the "Teacher Tip" sections are rendered using the blue pallet
-// where as "Digging Deeper" sections are rendered using the orange pallet.
+// There are several color pallets used for different purposes. A particular
+// pallet is applied to the UI, based on the type of (or the content of) a
+// particular widget being displayed.
 //
-// This partial defines variables, with more-or-less human readable names, for
-// the particular colors in each pallet.
+// For example, the "Teacher Tip" sections are rendered using the blue pallet
+// whereas "Digging Deeper" sections are rendered using the orange pallet.
+//
+// This partial SASS file defines variables with, more-or-less, human readable
+// names, for the specific colors in each pallet.
+
+$textBlack: #1A1A1A
 
 $darkYellow: #5E5E04
 $deepYellow: #878706
@@ -12,6 +16,7 @@ $mediumYellow: #C1C108
 $fullYellow: #FAFA15
 $brightYellow: #FDFDA4
 $paleYellow: #FEFEE3
+$lightYellow: #FCFC51
 
 $darkBlue: #073A70
 $deepBlue: #094F98
@@ -25,11 +30,13 @@ $deepOrange: #A66006
 $mediumOrange: #DC8008
 $fullOrange: #FDA61C
 $brightOrange: #FEDEB1
+$fadedOrange: #FEC164
 $paleOrange: #FFF4E5
 
 $darkPurple: #6B0E60
 $deepPurple: #871479
 $mediumPurple: #AB1C9A
 $fullPurple: #CB55BB
+$somePurple: #DE98D5
 $brightPurple: #EECEE9
 $palePurple: #F9EFF8

--- a/src/components/_themes.sass
+++ b/src/components/_themes.sass
@@ -3,6 +3,8 @@
 $radius: 25px
 $endCapRadius: 28px
 $labelFont: 24px arial, sans-serif
-$border: solid 3px
+$border-style: solid
+$border-width: 3px
 $padding: 45px 30px 28px 30px
 $borderRadius: 0px 0px $radius $radius
+$windowShadeButtonWidth: 400px

--- a/src/components/authoring/window-shade-form.tsx
+++ b/src/components/authoring/window-shade-form.tsx
@@ -7,7 +7,8 @@ import { getContentConfiguration } from "../../config/ui-configurations";
 const allConfigurationTypes = [
   WindowShadeType.TeacherTip,
   WindowShadeType.TheoryAndBackground,
-  WindowShadeType.DiscussionPoints
+  WindowShadeType.DiscussionPoints,
+  WindowShadeType.DiggingDeeper
 ];
 
 const allMediaTypes = [

--- a/src/components/button-title.sass
+++ b/src/components/button-title.sass
@@ -7,17 +7,23 @@
   flex-direction: column
   justify-content: center
   align-items: center
-  border: 3px solid
+  border: $border-width $border-style
   border-left: 0
   border-right: 0
-  &.theoryAndBackground
-    border-color: $yellowBorderColor
-  &.teacherTip
-    border-color: $blueBorderColor
-  &.discussionPoints
-    border-color: $orangeBorderColor
-  &.diggingDeeper
-    border-color: $purpleBorderColor
+  user-select: none
   
+.theoryAndBackground
+  border-color: $yellowBorderColor
+
+.teacherTip
+  border-color: $blueBorderColor
+
+.discussionPoints
+  border-color: $orangeBorderColor
+
+.diggingDeeper
+  border-color: $purpleBorderColor
+  
+
 
   

--- a/src/components/helpers/dot.sass
+++ b/src/components/helpers/dot.sass
@@ -1,0 +1,26 @@
+@import "../themes.sass"
+  
+.dot
+  width: 9px
+  height: 9px
+  border-radius: 4px
+  margin: -6px
+  z-index: 2000
+
+.dotLeft
+  float: left
+
+.dotRight
+  float: right
+
+.theoryAndBackground
+  background-color: $yellowBorderColor
+
+.teacherTip
+  background-color: $blueBorderColor
+
+.discussionPoints
+  background-color: $orangeBorderColor
+    
+.diggingDeeper
+  background-color: $purpleBorderColor

--- a/src/components/helpers/dot.tsx
+++ b/src/components/helpers/dot.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+
+import * as css from "./dot.sass";
+import { IWindowShadeConfiguration } from "../../config/ui-configurations";
+
+export enum sidePosition {
+  left,
+  right
+}
+
+interface IProps {
+  config: IWindowShadeConfiguration;
+  side: sidePosition;
+}
+
+export class Dot extends React.Component<IProps, {}> {
+  public render() {
+    const { config: {styleClassName}, side } = this.props;
+    const cssNames = [
+      css.dot,
+      side === sidePosition.left ? css.dotLeft : css.dotRight,
+      css[styleClassName]
+    ].join(" ");
+    return (
+      <div className={cssNames} />
+    );
+  }
+}

--- a/src/components/left-end-cap.sass
+++ b/src/components/left-end-cap.sass
@@ -1,27 +1,60 @@
 @import "themes.sass"
 
 .leftEndCap
+  position: relative
   width: 50px
   height: 50px
-  padding: 0
-  margin: 0
-  border: 3px solid
+  border: $border-width $border-style
+
+.theoryAndBackground
+  border-color: $yellowBorderColor
+  background-color: $yellowIconBackgroundColor
   border-radius: $endCapRadius 0 0 $endCapRadius
-  border-right: 0
+
+.teacherTip
+  border-color: $blueBorderColor
+  background-color: $blueIconBackgroundColor
+  border-radius: $endCapRadius 0 0 $endCapRadius
+
+.discussionPoints
+  border-color: $orangeBorderColor
+  background-color: $orangeIconBackgroundColor
+  border-radius: $endCapRadius 0 0 $endCapRadius
+
+.diggingDeeper
+  border-color: $purpleBorderColor
+  background-color: $purpleIconBackgroundColor
+  border-radius: $endCapRadius 0 0 $endCapRadius
+
+.icon
+  position: absolute
+  background-color: transparent
+
+.frontIcon
+  z-index: 1
+  // fill-opacity: 1
+  // stroke-opacity: 1
   &.theoryAndBackground
-    fill: $yellowIconColor
-    background-color: $yellowIconBackgroundColor
-    border-color: $yellowBorderColor
+    fill: $yellowFrontIconColor
   &.teacherTip
-    fill: $blueIconColor
-    background-color: $blueIconBackgroundColor
-    border-color: $blueBorderColor
+    fill: $blueFrontIconColor
   &.discussionPoints
-    fill: $orangeIconColor
-    background-color: $orangeIconBackgroundColor
-    border-color: $orangeBorderColor
+    fill: $orangeFrontIconColor
   &.diggingDeeper
-    fill: $purpleIconColor
-    background-color: $purpleIconBackgroundColor
-    border-color: $purpleBorderColor
-    
+    fill: $purpleFrontIconColor
+  
+.rearIcon
+  z-index: 2
+  fill-opacity: 0
+  transition: fill-opacity 0.25s ease
+  &.theoryAndBackground
+    fill: $yellowRearIconColor
+  &.teacherTip
+    fill: $blueRearIconColor
+  &.discussionPoints
+    fill: $orangeRearIconColor
+  &.diggingDeeper
+    fill: $purpleRearIconColor
+  &:hover
+    fill-opacity: 1
+    transition: fill-opacity 0.5s

--- a/src/components/left-end-cap.tsx
+++ b/src/components/left-end-cap.tsx
@@ -11,9 +11,14 @@ interface IProps {
 export default class LeftEndCap extends React.Component<IProps, {}> {
 
   public render() {
-    const { Icon, styleClassName } = this.props.config;
+    const { FrontIcon, RearIcon, styleClassName } = this.props.config;
+    const cssShadeType = css[styleClassName];
     return (
-      <Icon className={`${css.leftEndCap} ${css[styleClassName]}`} />
+      <div className={`${css.leftEndCap} ${cssShadeType}`}>
+        <RearIcon className={`${css.icon} ${cssShadeType} ${css.rearIcon}`} />
+        <FrontIcon className={`${css.icon} ${cssShadeType} ${css.frontIcon}`} />
+      </div>
     );
   }
+
 }

--- a/src/components/right-end-cap.sass
+++ b/src/components/right-end-cap.sass
@@ -5,21 +5,25 @@
   min-width: 50px
   padding: 0
   margin: 0
-  border: 3px solid
+  border: $border-width $border-style
   border-radius: 0 $endCapRadius $endCapRadius 0
   border-left: 0
-  &.theoryAndBackground
-    border-color: $yellowBorderColor
-    fill: $yellowMediaIconColor
-  &.teacherTip
-    border-color: $blueBorderColor
-    fill: $blueMediaIconColor
-  &.discussionPoints
-    border-color: $orangeBorderColor
-    fill: $orangeMediaIconColor
-  &.diggingDeeper
-    border-color: $purpleBorderColor
-    fill: $purpleMediaIconColor
+
+.theoryAndBackground
+  border-color: $yellowBorderColor
+  fill: $yellowMediaIconColor
+
+.teacherTip
+  border-color: $blueBorderColor
+  fill: $blueMediaIconColor
+
+.discussionPoints
+  border-color: $orangeBorderColor
+  fill: $orangeMediaIconColor
+
+.diggingDeeper
+  border-color: $purpleBorderColor
+  fill: $purpleMediaIconColor
 
 .mediaIcon
   width: 40px

--- a/src/components/right-end-cap.tsx
+++ b/src/components/right-end-cap.tsx
@@ -8,28 +8,27 @@ import Image from "../icons/image.svg";
 import Video from "../icons/video.svg";
 
 interface IProps {
-  mediaType: string;
   config: IWindowShadeConfiguration;
+  mediaType: string;
 }
 
 export default class RightEndCap extends React.Component<IProps, {}> {
 
   public render() {
-    const { mediaType, config: {styleClassName} } = this.props;
+    const { config: {styleClassName}, mediaType } = this.props;
     return (
       <div className={`${css.rightEndCap} ${css[styleClassName]}`}>
-        {this.getMediaIcon(mediaType, styleClassName)}
+        {this.getMediaIcon(mediaType)}
       </div>
     );
   }
 
-  private getMediaIcon(mediaType: string, styleClassName: string) {
-    const cssClassName = css.mediaIcon;
+  private getMediaIcon(mediaType: string) {
     switch (mediaType) {
       case "image":
-        return <Image className={`${cssClassName} ${styleClassName}`} />;
+        return <Image className={css.mediaIcon} />;
       case "video":
-        return <Video className={`${cssClassName} ${styleClassName}`} />;
+        return <Video className={css.mediaIcon} />;
       default:
         return "";
     }

--- a/src/components/window-shade-button.sass
+++ b/src/components/window-shade-button.sass
@@ -2,8 +2,8 @@
   
 .windowShadeButton
   top: -28px
-  left: 40px
-  max-width: 400px
+  left: 25px
+  max-width: $windowShadeButtonWidth
   height: 50px
   position: relative
   display: flex
@@ -13,36 +13,35 @@
   align-items: center
   font-weight: bold
   font-size: 18pt
+  border: none
   border-radius: $radius
   cursor: pointer
   user-select: none
+  
 .theoryAndBackground
-  background-color: $yellowBackgroundColor
-  border-color: $yellowBorderColor
-  color: $yellowTextColor
+  color: $yellowButtonTextColor
+  background-color: $yellowButtonBackgroundColor
   &:hover
-    background-color: $yellowBackgroundColorOnHover
+    color: $yellowButtonTextHoverColor
+    background-color: $yellowButtonBackgroundHoverColor
 
 .teacherTip
-  background-color: $blueBackgroundColor
-  border-color: $blueBorderColor
-  color: $blueTextColor
+  color: $blueButtonTextColor
+  background-color: $blueButtonBackgroundColor
   &:hover
-    background-color: $blueBackgroundColorOnHover
-    color: $blueTextColorOnHover
+    color: $blueButtonTextHoverColor
+    background-color: $blueButtonBackgroundHoverColor
 
 .discussionPoints
-  background-color: $orangeBackgroundColor
-  border-color: $orangeBorderColor
-  color: $orangeTextColor
+  color: $orangeButtonTextColor
+  background-color: $orangeButtonBackgroundColor
   &:hover
-    background-color: $orangeBackgroundColorOnHover
-    color: $orangeTextColorOnHover
+    color: $orangeButtonTextHoverColor
+    background-color: $orangeButtonBackgroundHoverColor
 
 .diggingDeeper
-  background-color: $purpleBackgroundColor
-  border-color: $purpleBorderColor
-  color: $purpleTextColor
+  color: $purpleButtonTextColor
+  background-color: $purpleButtonBackgroundColor
   &:hover
-    background-color: $purpleBackgroundColorOnHover
-    color: $purpleTextColorOnHover
+    color: $purpleButtonTextHoverColor
+    background-color: $purpleButtonBackgroundHoverColor

--- a/src/components/window-shade-button.sass
+++ b/src/components/window-shade-button.sass
@@ -2,7 +2,7 @@
   
 .windowShadeButton
   top: -28px
-  left: 45px
+  left: 40px
   max-width: 400px
   height: 50px
   position: relative

--- a/src/components/window-shade-button.tsx
+++ b/src/components/window-shade-button.tsx
@@ -1,27 +1,25 @@
 import * as React from "react";
 
 import * as css from "./window-shade-button.sass";
-import { WindowShadeType } from "../types";
 import { IWindowShadeConfiguration } from "../config/ui-configurations";
 import LeftEndCap from "./left-end-cap";
 import ButtonTitle from "./button-title";
 import RightEndCap from "./right-end-cap";
 
 interface IProps {
-  onClick: () => void;
-  mediaType: string;
   config: IWindowShadeConfiguration;
+  mediaType: string;
+  onClick: () => void;
 }
-
-interface IState { }
 
 // WindowShadeButton's are presentation-only components composed of 3 sub-
 // components: a LeftEndCap, a ButtonLabel, and a RightEndCap. This component
 // is responsible for aligning the 3 sub-components horizontally, the overall
-// size and shape of the button (a rounded rectangle), and the border of the
-// button.
+// size and shape of the button (a rounded rectangle). Since the LeftEndCap
+// component can be used, isolated from a WindowShadeButton, the responsibility
+// for rendering the borders are delegated to the there sub-components.
 
-export default class WindowShadeButton extends React.Component<IProps, IState> {
+export default class WindowShadeButton extends React.Component<IProps, {}> {
   public render() {
     const { onClick, mediaType, config } = this.props;
     const { label, styleClassName } = config;
@@ -29,8 +27,8 @@ export default class WindowShadeButton extends React.Component<IProps, IState> {
     return (
       <div className={cssClassNames.join(" ")} onClick={onClick}>
         <LeftEndCap config={config} />
-        <ButtonTitle title={label} config={config} />
-        <RightEndCap mediaType={mediaType} config={config} />
+        <ButtonTitle config={config} title={label} />
+        <RightEndCap config={config} mediaType={mediaType} />
       </div>
     );
   }

--- a/src/components/window-shade-content.sass
+++ b/src/components/window-shade-content.sass
@@ -9,39 +9,73 @@
   margin-bottom: 12pt
 
 .theoryAndBackground
-  color: $yellowTextColor
-  border-color: $yellowBorderColor
-  background-color: $yellowContentBackgroundColor
+  color: $yellowContentTextColor
   &.authorMarkdown
     h1,h2,h3,h4,h5,th,em,strong
-      color: $yellowHilitText
-    th
-      border-bottom: $yellowHilitText 2px solid
-    td
-      border-bottom: $yellowHilitText 1px solid
-      border-left: $yellowHilitText 1px solid
-      border-right: $yellowHilitText 1px solid
+      color: $yellowContentTextAccentColor
+    table
+      border-collapse: collapse
+    th, td
+      padding-left: 10px
+      padding-right: 19px
+      border-right: 1px solid $yellowContentTextColor
+      border-bottom: 1px solid $yellowContentTextColor
+    th:last-child, td:last-child
+      border-right: none
+    tr:last-child
+      td
+        border-bottom: none
      
 .teacherTip
-  color: $blueBorderColor
-  border-color: $blueBorderColor
-  background-color: $blueContentBackgroundColor
+  color: $blueContentTextColor
   &.authorMarkdown
     h1,h2,h3,h4,h5,th,em,strong
-      color: $blueHilitText
+      color: $blueContentTextAccentColor
+    table
+      border-collapse: collapse
+    th, td
+      padding-left: 10px
+      padding-right: 19px
+      border-right: 1px solid $blueContentTextColor
+      border-bottom: 1px solid $blueContentTextColor
+    th:last-child, td:last-child
+      border-right: none
+    tr:last-child
+      td
+        border-bottom: none
 
 .discussionPoints
-  color: $orangeBorderColor
-  border-color: $orangeBorderColor
-  background-color: $orangeContentBackgroundColor
+  color: $orangeContentTextColor
   &.authorMarkdown
     h1,h2,h3,h4,h5,th,em,strong
-      color: $orangeHilitText
+      color: $orangeContentTextAccentColor
+    table
+      border-collapse: collapse
+    th, td
+      padding-left: 10px
+      padding-right: 19px
+      border-right: 1px solid $orangeContentTextColor
+      border-bottom: 1px solid $orangeContentTextColor
+    th:last-child, td:last-child
+      border-right: none
+    tr:last-child
+      td
+        border-bottom: none
 
 .diggingDeeper
-  color: $purpleBorderColor
-  border-color: $purpleBorderColor
-  background-color: $purpleContentBackgroundColor
+  color: $purpleContentTextColor
   &.authorMarkdown
     h1,h2,h3,h4,h5,th,em,strong
-      color: $purpleHilitText
+      color: $purpleContentTextAccentColor
+    table
+      border-collapse: collapse
+    th, td
+      padding-left: 10px
+      padding-right: 19px
+      border-right: 1px solid $purpleContentTextColor
+      border-bottom: 1px solid $purpleContentTextColor
+    th:last-child, td:last-child
+      border-right: none
+    tr:last-child
+      td
+        border-bottom: none

--- a/src/components/window-shade-content.sass
+++ b/src/components/window-shade-content.sass
@@ -11,7 +11,7 @@
 .theoryAndBackground
   color: $yellowTextColor
   border-color: $yellowBorderColor
-  background-color: $paleYellow
+  background-color: $yellowContentBackgroundColor
   &.authorMarkdown
     h1,h2,h3,h4,h5,th,em,strong
       color: $yellowHilitText
@@ -21,12 +21,11 @@
       border-bottom: $yellowHilitText 1px solid
       border-left: $yellowHilitText 1px solid
       border-right: $yellowHilitText 1px solid
-
-      
+     
 .teacherTip
   color: $blueBorderColor
   border-color: $blueBorderColor
-  background-color: $paleBlue
+  background-color: $blueContentBackgroundColor
   &.authorMarkdown
     h1,h2,h3,h4,h5,th,em,strong
       color: $blueHilitText
@@ -34,7 +33,7 @@
 .discussionPoints
   color: $orangeBorderColor
   border-color: $orangeBorderColor
-  background-color: $paleOrange
+  background-color: $orangeContentBackgroundColor
   &.authorMarkdown
     h1,h2,h3,h4,h5,th,em,strong
       color: $orangeHilitText
@@ -42,7 +41,7 @@
 .diggingDeeper
   color: $purpleBorderColor
   border-color: $purpleBorderColor
-  background-color: $palePurple
+  background-color: $purpleContentBackgroundColor
   &.authorMarkdown
     h1,h2,h3,h4,h5,th,em,strong
       color: $purpleHilitText

--- a/src/components/window-shade.sass
+++ b/src/components/window-shade.sass
@@ -3,46 +3,26 @@
 .windowShade
   min-width: 480px
   font: $labelFont
-  border: $border
   border-radius: $borderRadius
   margin-top: 50px
   margin-bottom: 75px
-  border: $border
-
-.dot
-  width: 9px
-  height: 9px
-  border-radius: 4px
-  margin: -6px
-  z-index: 2000
-  &.dotLeft
-    float: left
-  &.dotRight
-    float: right
-
+  border: $border-style $border-width
+  
 .theoryAndBackground
   border-color: $yellowBorderColor
   background-color: $yellowContentBackgroundColor
-  .dot
-    background: $yellowBorderColor
 
 .teacherTip
   border-color: $blueBorderColor
   background-color: $blueContentBackgroundColor
-  .dot
-    background: $blueBorderColor
 
 .discussionPoints
   border-color: $orangeBorderColor
   background-color: $orangeContentBackgroundColor
-  .dot
-    background: $orangeBorderColor
 
 .diggingDeeper
   border-color: $purpleBorderColor
   background-color: $purpleContentBackgroundColor
-  .dot
-    background: $purpleBorderColor
 
 .windowShadeShown
   height: auto
@@ -53,6 +33,7 @@
   border-right: 0
   border-bottom: 0
   border-radius: 0
+  margin-right: 3px;
   .content
     height: 0
     overflow: hidden

--- a/src/components/window-shade.sass
+++ b/src/components/window-shade.sass
@@ -1,6 +1,7 @@
 @import "themes.sass"
 
 .windowShade
+  min-width: 480px
   font: $labelFont
   border: $border
   border-radius: $borderRadius
@@ -8,28 +9,47 @@
   margin-bottom: 75px
   border: $border
 
+.dot
+  width: 9px
+  height: 9px
+  border-radius: 4px
+  margin: -6px
+  z-index: 2000
+  &.dotLeft
+    float: left
+  &.dotRight
+    float: right
+
 .theoryAndBackground
   border-color: $yellowBorderColor
-  background-color: $paleYellow
+  background-color: $yellowContentBackgroundColor
+  .dot
+    background: $yellowBorderColor
 
 .teacherTip
   border-color: $blueBorderColor
-  background-color: $paleBlue
+  background-color: $blueContentBackgroundColor
+  .dot
+    background: $blueBorderColor
 
 .discussionPoints
   border-color: $orangeBorderColor
-  background-color: $paleOrange
+  background-color: $orangeContentBackgroundColor
+  .dot
+    background: $orangeBorderColor
 
 .diggingDeeper
   border-color: $purpleBorderColor
-  background-color: $palePurple
+  background-color: $purpleContentBackgroundColor
+  .dot
+    background: $purpleBorderColor
 
 .windowShadeShown
   height: auto
 
 .windowShadeHidden
   height: 0
-  border-left: 0
+  border-left: -3px
   border-right: 0
   border-bottom: 0
   border-radius: 0

--- a/src/components/window-shade.test.tsx
+++ b/src/components/window-shade.test.tsx
@@ -11,6 +11,6 @@ const windowShadeProps = {
 describe("WindowShade component", () => {
   it("renders Hello World", () => {
     const wrapper = shallow(<WindowShade authoredState={windowShadeProps}/>);
-    expect(wrapper.text()).toEqual("<WindowShadeButton /><WindowShadeContent />");
+    expect(wrapper.text()).toEqual("<Dot /><Dot /><WindowShadeButton /><WindowShadeContent />");
   });
 });

--- a/src/components/window-shade.tsx
+++ b/src/components/window-shade.tsx
@@ -5,15 +5,17 @@ import { IWindowShade, MediaType } from "../types";
 import { WindowShadeConfigurations } from "../config/ui-configurations";
 import WindowShadeButton from "./window-shade-button";
 import WindowShadeContent from "./window-shade-content";
+import { Dot, sidePosition } from "./helpers/dot";
 
 interface IProps {
   authoredState: IWindowShade;
 }
+
 interface IState {
   open: boolean;
 }
 
-// WindowShades are rendered across the whole width of the page and are composed
+// WindowShades render across the whole width of the page and are composed
 // of a WindowShadeButton and a WindowShadeContent. When a WindowShadeButton
 // is clicked, the Boolean state variable "open" is toggled. The value of this
 // state variable controls the display state, visible or hidden, of the
@@ -34,12 +36,12 @@ export default class WindowShade extends React.Component<IProps, IState> {
 
     return (
       <div className={`${css.windowShade} ${cssShadeType} ${cssOpenState}`} >
-        <div className={`${css.dot} ${css.dotLeft}`} />
-        <div className={`${css.dot} ${css.dotRight}`} />
+        <Dot config={config} side={sidePosition.left} />
+        <Dot config={config} side={sidePosition.right} />
         <WindowShadeButton
-          onClick={this.toggle}
-          mediaType={mediaType ? mediaType : MediaType.None}
           config={config}
+          mediaType={mediaType ? mediaType : MediaType.None}
+          onClick={this.toggle}
         />
         <div className={`${css.content} ${cssShadeType}`}>
           <WindowShadeContent content={content} config={config} />
@@ -49,7 +51,6 @@ export default class WindowShade extends React.Component<IProps, IState> {
   }
 
   private toggle = () => {
-    const { open } = this.state;
-    this.setState({open: !open});
+    this.setState({open: !this.state.open});
   }
 }

--- a/src/components/window-shade.tsx
+++ b/src/components/window-shade.tsx
@@ -34,6 +34,8 @@ export default class WindowShade extends React.Component<IProps, IState> {
 
     return (
       <div className={`${css.windowShade} ${cssShadeType} ${cssOpenState}`} >
+        <div className={`${css.dot} ${css.dotLeft}`} />
+        <div className={`${css.dot} ${css.dotRight}`} />
         <WindowShadeButton
           onClick={this.toggle}
           mediaType={mediaType ? mediaType : MediaType.None}

--- a/src/config/ui-configurations.tsx
+++ b/src/config/ui-configurations.tsx
@@ -1,37 +1,46 @@
 import ExclamationA from "../icons/exclamation_A.svg";
+import ExclamationB from "../icons/exclamation_B.svg";
 import DiscussionA from "../icons/discussion_A.svg";
+import DiscussionB from "../icons/discussion_B.svg";
 import LightbulbA from "../icons/lightbulb_A.svg";
+import LightbulbB from "../icons/lightbulb_B.svg";
 import ShovelA from "../icons/shovel_A.svg";
+import ShovelB from "../icons/shovel_B.svg";
 
 export interface IWindowShadeConfiguration {
-  Icon: SvgrComponent;
-  BackingIcon?: SvgrComponent;
+  FrontIcon: SvgrComponent;
+  RearIcon: SvgrComponent;
   label: string;
   styleClassName: string;
 }
 
 export const WindowShadeConfigurations: {[index: string]: IWindowShadeConfiguration} = {
   teacherTip: {
-    Icon: ExclamationA,
+    FrontIcon: ExclamationA,
+    RearIcon: ExclamationB,
     label: "Teacher Tip",
     styleClassName: "teacherTip"
   },
   theoryAndBackground: {
-    Icon: LightbulbA,
+    FrontIcon: LightbulbA,
+    RearIcon: LightbulbB,
     label: "Theory & Background",
     styleClassName: "theoryAndBackground"
   },
   discussionPoints: {
-    Icon: DiscussionA,
+    FrontIcon: DiscussionA,
+    RearIcon: DiscussionB,
     label: "Discussion Points",
     styleClassName: "discussionPoints",
   },
   diggingDeeper: {
-    Icon: ShovelA,
+    FrontIcon: ShovelA,
+    RearIcon: ShovelB,
     label: "Digging Deeper",
     styleClassName: "diggingDeeper",
   }
 };
+
 export const getContentConfiguration = (key: string) => {
   return WindowShadeConfigurations[key];
 };


### PR DESCRIPTION
Adds a bunch of the styling support we need to have for MVP, including:

* Dots on the top-left and top-right corners of the WindowShade component that remain when the WindowShade is collapsed (dots are implemented as a presentation-level React component for reuse in other areas.

* Additional styling for the markdown inside a WindowShadeContent and extended to all window shade types, not just theoryAndBackground & teacherTips.

* Decomposed the WindowShadeButton into sub-components, in particular, the LeftEndCap component, so that it may be used outside of a WindowShadeButton and render it's own border.

* Added support for the two-part icons, like the lightbulb & exclamation point, so hover-over behavior and "light-up" the icon. (Note, hover state of the two-part icon is not yet connected to the hover over of the text of button. That work is TBD.)

* Made a pass over all the color style variables and reconciled hex-values with UI spec.

* Little tweaks to the WindowShadeButton:
  * Preventing text selection inside the button
  * Adjustment of the relative sizes and alignment of the subcomponents
  * Fixed an annoying "jump" of the top-right Dot when open/close state is toggled

This doesn't PR doesn't complete all the clean-up styling work -- mostly just the structural problems (decomposing React components, managing the SASS class names, etc) were addressed here. A few others will be captured in a follow-up PT user story.