### PR TITLE
Adjust windowShade margins to behave better at runtime.

### DIFF
--- a/src/components/window-shade.sass
+++ b/src/components/window-shade.sass
@@ -4,8 +4,8 @@
   min-width: 480px
   font: $labelFont
   border-radius: $borderRadius
-  margin-top: 50px
-  margin-bottom: 75px
+  margin-top: 27px
+  margin-bottom: 27px
   border: $border-style $border-width
   
 .theoryAndBackground

--- a/src/demo.tsx
+++ b/src/demo.tsx
@@ -113,17 +113,38 @@ const authoredStateDVgSection: IWindowShade = {
   tabNameOverride: "SVG Icons"
 };
 
+const windowShadeContainerDivStyle = {
+  marginTop: "23px",
+  marginBottom: "73px"
+};
+
 // props = {authoredState: {type: 'dd', content:'xx'} }
 ReactDOM.render(
   <div>
-    <WindowShade authoredState={authoredStateA} />
-    <WindowShade authoredState={authoredStateB} />
-    <WindowShade authoredState={authoredStateC} />
-    <WindowShade authoredState={authoredStateD} />
-    <WindowShade authoredState={authoredStateE} />
-    <WindowShade authoredState={authoredStateF} />
-    <WindowShade authoredState={authoredStateG} />
-    <WindowShade authoredState={authoredStateH} />
+    <div style={windowShadeContainerDivStyle}>
+      <WindowShade authoredState={authoredStateA} />
+    </div>
+    <div style={windowShadeContainerDivStyle}>
+      <WindowShade authoredState={authoredStateB} />
+    </div>
+    <div style={windowShadeContainerDivStyle}>
+      <WindowShade authoredState={authoredStateC} />
+    </div>
+    <div style={windowShadeContainerDivStyle}>
+      <WindowShade authoredState={authoredStateD} />
+    </div>
+    <div style={windowShadeContainerDivStyle}>
+      <WindowShade authoredState={authoredStateE} />
+    </div>
+    <div style={windowShadeContainerDivStyle}>
+      <WindowShade authoredState={authoredStateF} />
+    </div>
+    <div style={windowShadeContainerDivStyle}>
+      <WindowShade authoredState={authoredStateG} />
+    </div>
+    <div style={windowShadeContainerDivStyle}>
+      <WindowShade authoredState={authoredStateH} />
+    </div>
     <div>
       <br />
       <span>Display of all icons:</span>


### PR DESCRIPTION
Although the original top/bottom margins of 50px/75px looked fine in the demo page, those were far to great a size for the display at runtime. These have been adjusted to made the bounding margins more appropriate to the height of the window-shade-button.

To adjust the demo page, accordingly, a div was used to wrap all of the WindowShade component displays in `demo.tsx`.

The authoring page looks a little bit squished but is still acceptable, so that was left alone.