### PR TITLE
161965279 add analytics support

### DIFF
--- a/src/components/question-wrapper.tsx
+++ b/src/components/question-wrapper.tsx
@@ -233,10 +233,10 @@ export default class QuestionWrapper extends React.Component<IProps, IState> {
     const {tabOpened, tabClosed} = AnalyiticsActionType;
     const action = (activeTab === tabName) ? tabClosed : tabOpened;
     const nextTab = (action === tabClosed) ? null : tabName;
-    this.setState({activeTab: nextTab}, () => this.logAction(action));
+    this.setState({activeTab: nextTab}, () => this.logAction(action, tabName));
   }
 
-  private logAction = (action: AnalyiticsActionType) => {
+  private logAction = (action: AnalyiticsActionType, tabName = "none") => {
     const location = (action === AnalyiticsActionType.loaded)
       ? window.location.toString()
       : undefined;
@@ -244,7 +244,7 @@ export default class QuestionWrapper extends React.Component<IProps, IState> {
     logAnalyticsEvent({
       tipType: TeacherTipType.QuestionWrapper,
       eventAction: action,
-      tabName: this.state.activeTab || "none",
+      tabName,
       location
     });
   }

--- a/src/components/question-wrapper.tsx
+++ b/src/components/question-wrapper.tsx
@@ -9,7 +9,7 @@ import CheckMark from "../icons/check_mark.svg";
 import XMark from "../icons/x_mark.svg";
 import * as css from "./question-wrapper.sass";
 import {
-  logAnalyticsEvent, ILogEvent, AnalyiticsActionType
+  logAnalyticsEvent, ILogEvent, AnalyticsActionType
 } from "../utilities/analytics";
 
 type TabName = "Correct" | "Distractors" | "TeacherTip" | "Exemplar";
@@ -47,7 +47,7 @@ export default class QuestionWrapper extends React.Component<IProps, IState> {
       // Find multiple choice answer inputs. Used later to position icons.
       this.answerInputs = this.findInputsInWrappedQuestion();
     }
-    this.logAction(AnalyiticsActionType.loaded);
+    this.logAction(AnalyticsActionType.loaded);
   }
 
   public render() {
@@ -230,14 +230,14 @@ export default class QuestionWrapper extends React.Component<IProps, IState> {
 
   private toggleTab = (tabName: TabName) => {
     const { activeTab } = this.state;
-    const {tabOpened, tabClosed} = AnalyiticsActionType;
+    const {tabOpened, tabClosed} = AnalyticsActionType;
     const action = (activeTab === tabName) ? tabClosed : tabOpened;
     const nextTab = (action === tabClosed) ? null : tabName;
     this.setState({activeTab: nextTab}, () => this.logAction(action, tabName));
   }
 
-  private logAction = (action: AnalyiticsActionType, tabName = "none") => {
-    const location = (action === AnalyiticsActionType.loaded)
+  private logAction = (action: AnalyticsActionType, tabName = "none") => {
+    const location = (action === AnalyticsActionType.loaded)
       ? window.location.toString()
       : undefined;
 

--- a/src/components/question-wrapper.tsx
+++ b/src/components/question-wrapper.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import Markdown from "markdown-to-jsx";
-import { IAuthoredQuestionWrapper } from "../types";
+import { IAuthoredQuestionWrapper, TeacherTipType } from "../types";
 import CheckA from "../icons/check_A.svg";
 import XA from "../icons/x_A.svg";
 import ExclamationSmall from "../icons/exclamation_small_A.svg";
@@ -8,6 +8,9 @@ import Exclamation from "../icons/exclamation_A.svg";
 import CheckMark from "../icons/check_mark.svg";
 import XMark from "../icons/x_mark.svg";
 import * as css from "./question-wrapper.sass";
+import {
+  logAnalyticsEvent, ILogEvent, AnalyiticsActionType
+} from "../utilities/analytics";
 
 type TabName = "Correct" | "Distractors" | "TeacherTip" | "Exemplar";
 
@@ -44,6 +47,7 @@ export default class QuestionWrapper extends React.Component<IProps, IState> {
       // Find multiple choice answer inputs. Used later to position icons.
       this.answerInputs = this.findInputsInWrappedQuestion();
     }
+    this.logAction(AnalyiticsActionType.loaded);
   }
 
   public render() {
@@ -219,23 +223,29 @@ export default class QuestionWrapper extends React.Component<IProps, IState> {
     return wrappedEmbeddableDiv.querySelectorAll(`input[type="${inputType}"]`) as NodeListOf<HTMLInputElement>;
   }
 
-  private toggleCorrect = () => {
+  private toggleCorrect = () => this.toggleTab("Correct");
+  private toggleDistractors = () => this.toggleTab("Distractors");
+  private toggleTeacherTip = () => this.toggleTab("TeacherTip");
+  private toggleExemplar = () => this.toggleTab("Exemplar");
+
+  private toggleTab = (tabName: TabName) => {
     const { activeTab } = this.state;
-    this.setState({ activeTab: activeTab === "Correct" ? null : "Correct" });
+    const {tabOpened, tabClosed} = AnalyiticsActionType;
+    const action = (activeTab === tabName) ? tabClosed : tabOpened;
+    const nextTab = (action === tabClosed) ? null : tabName;
+    this.setState({activeTab: nextTab}, () => this.logAction(action));
   }
 
-  private toggleDistractors = () => {
-    const { activeTab } = this.state;
-    this.setState({ activeTab: activeTab === "Distractors" ? null : "Distractors" });
-  }
+  private logAction = (action: AnalyiticsActionType) => {
+    const location = (action === AnalyiticsActionType.loaded)
+      ? window.location.toString()
+      : undefined;
 
-  private toggleTeacherTip = () => {
-    const { activeTab } = this.state;
-    this.setState({ activeTab: activeTab === "TeacherTip" ? null : "TeacherTip" });
-  }
-
-  private toggleExemplar = () => {
-    const { activeTab } = this.state;
-    this.setState({ activeTab: activeTab === "Exemplar" ? null : "Exemplar" });
+    logAnalyticsEvent({
+      tipType: TeacherTipType.QuestionWrapper,
+      eventAction: action,
+      tabName: this.state.activeTab || "none",
+      location
+    });
   }
 }

--- a/src/components/side-tip.tsx
+++ b/src/components/side-tip.tsx
@@ -2,7 +2,10 @@ import * as React from "react";
 import sideBarIcon from "../side-bar-icon";
 import Markdown from "markdown-to-jsx";
 import * as css from "./side-tip.sass";
-import { ISideTip } from "../types";
+import { ISideTip, TeacherTipType } from "../types";
+import {
+  logAnalyticsEvent, ILogEvent, AnalyiticsActionType
+} from "../utilities/analytics";
 
 interface IProps {
   authoredState: ISideTip;
@@ -55,7 +58,31 @@ export default class SideTip extends React.Component<IProps, IState> {
       width: 450,
       height: 500,
       padding: 0,
-      content: portalDom
+      content: portalDom,
+      onOpen: this.onOpen,
+      onClose: this.onClose
+    });
+    this.logAction(AnalyiticsActionType.loaded);
+  }
+
+  private onOpen = () => {
+    this.logAction(AnalyiticsActionType.tabOpened);
+  }
+
+  private onClose = () => {
+    this.logAction(AnalyiticsActionType.tabClosed);
+  }
+
+  private logAction = (action: AnalyiticsActionType) => {
+    const location = (action === AnalyiticsActionType.loaded)
+      ? window.location.toString()
+      : undefined;
+
+    logAnalyticsEvent({
+      tipType: TeacherTipType.SideTip,
+      eventAction: action,
+      tabName: "SideTip",
+      location
     });
   }
 }

--- a/src/components/side-tip.tsx
+++ b/src/components/side-tip.tsx
@@ -4,7 +4,7 @@ import Markdown from "markdown-to-jsx";
 import * as css from "./side-tip.sass";
 import { ISideTip, TeacherTipType } from "../types";
 import {
-  logAnalyticsEvent, ILogEvent, AnalyiticsActionType
+  logAnalyticsEvent, ILogEvent, AnalyticsActionType
 } from "../utilities/analytics";
 
 interface IProps {
@@ -62,19 +62,19 @@ export default class SideTip extends React.Component<IProps, IState> {
       onOpen: this.onOpen,
       onClose: this.onClose
     });
-    this.logAction(AnalyiticsActionType.loaded);
+    this.logAction(AnalyticsActionType.loaded);
   }
 
   private onOpen = () => {
-    this.logAction(AnalyiticsActionType.tabOpened);
+    this.logAction(AnalyticsActionType.tabOpened);
   }
 
   private onClose = () => {
-    this.logAction(AnalyiticsActionType.tabClosed);
+    this.logAction(AnalyticsActionType.tabClosed);
   }
 
-  private logAction = (action: AnalyiticsActionType) => {
-    const location = (action === AnalyiticsActionType.loaded)
+  private logAction = (action: AnalyticsActionType) => {
+    const location = (action === AnalyticsActionType.loaded)
       ? window.location.toString()
       : undefined;
 

--- a/src/components/window-shade.tsx
+++ b/src/components/window-shade.tsx
@@ -8,7 +8,7 @@ import WindowShadeContent from "./window-shade-content";
 import { Dot, sidePosition } from "./helpers/dot";
 import { TeacherTipType } from "../types";
 import {
-  logAnalyticsEvent, ILogEvent, AnalyiticsActionType
+  logAnalyticsEvent, ILogEvent, AnalyticsActionType
 } from "../utilities/analytics";
 
 interface IProps {
@@ -61,18 +61,18 @@ export default class WindowShade extends React.Component<IProps, IState> {
   }
 
   public componentDidMount() {
-    this.logAction(AnalyiticsActionType.loaded);
+    this.logAction(AnalyticsActionType.loaded);
   }
 
   private toggle = () => {
     const nextOpen = !this.state.open;
-    const action = nextOpen ? AnalyiticsActionType.tabOpened : AnalyiticsActionType.tabClosed;
+    const action = nextOpen ? AnalyticsActionType.tabOpened : AnalyticsActionType.tabClosed;
     this.setState({open: nextOpen});
     this.logAction(action);
   }
 
-  private logAction = (action: AnalyiticsActionType) => {
-    const location = (action === AnalyiticsActionType.loaded)
+  private logAction = (action: AnalyticsActionType) => {
+    const location = (action === AnalyticsActionType.loaded)
       ? window.location.toString()
       : undefined;
 

--- a/src/components/window-shade.tsx
+++ b/src/components/window-shade.tsx
@@ -6,6 +6,10 @@ import { WindowShadeConfigurations } from "../config/ui-configurations";
 import WindowShadeButton from "./window-shade-button";
 import WindowShadeContent from "./window-shade-content";
 import { Dot, sidePosition } from "./helpers/dot";
+import { TeacherTipType } from "../types";
+import {
+  logAnalyticsEvent, ILogEvent, AnalyiticsActionType
+} from "../utilities/analytics";
 
 interface IProps {
   authoredState: IWindowShade;
@@ -56,7 +60,27 @@ export default class WindowShade extends React.Component<IProps, IState> {
     );
   }
 
+  public componentDidMount() {
+    this.logAction(AnalyiticsActionType.loaded);
+  }
+
   private toggle = () => {
-    this.setState({open: !this.state.open});
+    const nextOpen = !this.state.open;
+    const action = nextOpen ? AnalyiticsActionType.tabOpened : AnalyiticsActionType.tabClosed;
+    this.setState({open: nextOpen});
+    this.logAction(action);
+  }
+
+  private logAction = (action: AnalyiticsActionType) => {
+    const location = (action === AnalyiticsActionType.loaded)
+      ? window.location.toString()
+      : undefined;
+
+    logAnalyticsEvent({
+      tipType: TeacherTipType.WindowShade,
+      eventAction: action,
+      tabName: this.props.authoredState.windowShadeType,
+      location
+    });
   }
 }

--- a/src/utilities/analytics.ts
+++ b/src/utilities/analytics.ts
@@ -7,7 +7,7 @@
 
 import { TeacherTipType } from "../types";
 
-export enum AnalyiticsActionType {
+export enum AnalyticsActionType {
   loaded = "TeacherTip Loaded",
   tabOpened = "TeacherTip TabOpened",
   tabClosed = "TeacherTip TabClosed"
@@ -15,7 +15,7 @@ export enum AnalyiticsActionType {
 
 export interface ILogEvent {
   readonly tipType: TeacherTipType | "";
-  readonly eventAction: AnalyiticsActionType;
+  readonly eventAction: AnalyticsActionType;
   readonly tabName: string;
   readonly location?: string;
 }
@@ -33,7 +33,7 @@ interface IAnalyticsService {
 }
 
 // We create a service that looks like Google's `window.ga` interface
-// but mearly logs to the console.
+// but merely logs to the console.
 // TSLint doesn't like console messages.
 const mockGa = {
   // tslint:disable no-console

--- a/src/utilities/analytics.ts
+++ b/src/utilities/analytics.ts
@@ -1,4 +1,10 @@
 
+/**************************************************************
+ * This file exports a few interfaces and a single function
+ * `logAnalyticsEvent` which is a small wrapper around
+ * Google Analytics service custom event logging.
+ *************************************************************/
+
 import { TeacherTipType } from "../types";
 
 export enum AnalyiticsActionType {
@@ -14,20 +20,24 @@ export interface ILogEvent {
   readonly location?: string;
 }
 
+// See Google Documentation on event logging and `fieldsObject` here:
+// https://developers.google.com/analytics/devguides/collection/analyticsjs/events
 interface IGAData {
-  readonly hitType: "event";
   readonly eventCategory: string;
-  readonly eventAction?: string;
-  readonly eventLabel?: string;
+  readonly eventAction: string;
+  readonly eventLabel: string;
 }
 
 interface IAnalyticsService {
-  ga?: (send: "send", data: IGAData) => void;
+  ga?: (send: "send", type: "event", data: IGAData) => void;
 }
 
+// We create a service that looks like Google's `window.ga` interface
+// but mearly logs to the console.
+// TSLint doesn't like console messages.
 const mockGa = {
   // tslint:disable no-console
-  ga: (send: "send", data: IGAData) => {
+  ga: (send: "send", type: "event", data: IGAData) => {
     console.group("Mock analytics send payload:");
     console.debug(send);
     console.debug(JSON.stringify(data, null, 2));
@@ -40,17 +50,17 @@ export const logAnalyticsEvent = (event: ILogEvent) => {
   const windowWithPossibleGa = (window as IAnalyticsService);
 
   const payload: IGAData = {
-    hitType: "event",
     eventCategory: event.tipType,
     eventAction: event.eventAction,
     eventLabel: event.location ? event.location : event.tabName
   };
 
+  // Above all do no harm:
   try {
     if (windowWithPossibleGa.ga instanceof Function) {
-      windowWithPossibleGa.ga("send", payload);
+      windowWithPossibleGa.ga("send", "event", payload);
     } else {
-      mockGa.ga("send", payload);
+      mockGa.ga("send", "event", payload);
     }
   } catch (e) {
     // tslint:disable no-console

--- a/src/utilities/analytics.ts
+++ b/src/utilities/analytics.ts
@@ -26,12 +26,14 @@ interface IAnalyticsService {
 }
 
 const mockGa = {
+  // tslint:disable no-console
   ga: (send: "send", data: IGAData) => {
-    console.group("mock analytics send payload:");
-    console.log(send);
-    console.log(JSON.stringify(data, null, 2));
+    console.group("Mock analytics send payload:");
+    console.debug(send);
+    console.debug(JSON.stringify(data, null, 2));
     console.groupEnd();
   }
+  // tslint:enable no-console
 };
 
 export const logAnalyticsEvent = (event: ILogEvent) => {
@@ -44,10 +46,17 @@ export const logAnalyticsEvent = (event: ILogEvent) => {
     eventLabel: event.location ? event.location : event.tabName
   };
 
-  if (windowWithPossibleGa.ga instanceof Function) {
-    windowWithPossibleGa.ga("send", payload);
-  } else {
-    mockGa.ga("send", payload);
+  try {
+    if (windowWithPossibleGa.ga instanceof Function) {
+      windowWithPossibleGa.ga("send", payload);
+    } else {
+      mockGa.ga("send", payload);
+    }
+  } catch (e) {
+    // tslint:disable no-console
+    console.error("Unable to send Google Analytics");
+    console.error(e);
+    // tslint:enable no-console
   }
 
 };

--- a/src/utilities/analytics.ts
+++ b/src/utilities/analytics.ts
@@ -1,0 +1,53 @@
+
+import { TeacherTipType } from "../types";
+
+export enum AnalyiticsActionType {
+  loaded = "tip Loaded",
+  tabOpened = "tip TabOpened",
+  tabClosed = "tip TabClosed"
+}
+
+export interface ILogEvent {
+  readonly tipType: TeacherTipType | "";
+  readonly eventAction: AnalyiticsActionType;
+  readonly tabName: string;
+  readonly location?: string;
+}
+
+interface IGAData {
+  readonly hitType: "event";
+  readonly eventCategory: string;
+  readonly eventAction?: string;
+  readonly eventLabel?: string;
+}
+
+interface IAnalyticsService {
+  ga?: (send: "send", data: IGAData) => void;
+}
+
+const mockGa = {
+  ga: (send: "send", data: IGAData) => {
+    console.group("mock analytics send payload:");
+    console.log(send);
+    console.log(JSON.stringify(data, null, 2));
+    console.groupEnd();
+  }
+};
+
+export const logAnalyticsEvent = (event: ILogEvent) => {
+  const windowWithPossibleGa = (window as IAnalyticsService);
+
+  const payload: IGAData = {
+    hitType: "event",
+    eventCategory: event.tipType,
+    eventAction: event.eventAction,
+    eventLabel: event.location ? event.location : event.tabName
+  };
+
+  if (windowWithPossibleGa.ga instanceof Function) {
+    windowWithPossibleGa.ga("send", payload);
+  } else {
+    mockGa.ga("send", payload);
+  }
+
+};

--- a/src/utilities/analytics.ts
+++ b/src/utilities/analytics.ts
@@ -2,9 +2,9 @@
 import { TeacherTipType } from "../types";
 
 export enum AnalyiticsActionType {
-  loaded = "tip Loaded",
-  tabOpened = "tip TabOpened",
-  tabClosed = "tip TabClosed"
+  loaded = "TeacherTip Loaded",
+  tabOpened = "TeacherTip TabOpened",
+  tabClosed = "TeacherTip TabClosed"
 }
 
 export interface ILogEvent {


### PR DESCRIPTION

`src/utilities/analytics.ts` is a light wrapper façade around Google Analytics (`window.ga`).  
If `window.ga` is defined we will send anytics event there.  Otherwise we put them in console debug messages.

Our various teacher tip click handlers and initializers were modified to send events through `analytics.ts`

@DALove1025 please review when you have a moment.