### PR TITLE
Final styling pass -- paragraph and element spacing issues

### DIFF
--- a/src/components/_themes.sass
+++ b/src/components/_themes.sass
@@ -21,3 +21,7 @@ $captionFont: Arial, sans-serif
 $captionWeight: normal
 $captionSize: 10.5pt
 $captionHeight: 12.75pt
+
+$tabFont: Roboto, sans-serif
+$tabWeight: bold
+$tabSize: 13.5pt

--- a/src/components/authoring/authoring-app.sass
+++ b/src/components/authoring/authoring-app.sass
@@ -1,7 +1,7 @@
 .container
+  margin-top: 40px;
   display: grid;
   grid-template-columns: 400px auto;
-
 
 .selector
   grid-column: 1

--- a/src/components/question-wrapper.sass
+++ b/src/components/question-wrapper.sass
@@ -1,3 +1,5 @@
+@import "themes.sass"
+  
 .questionWrapper
   .headers
     height: 50px
@@ -8,8 +10,9 @@
       max-width: 210px
       flex: 1
       white-space: nowrap
-      font-size: 16px
-      font-weight: bold
+      font-family: $tabFont
+      font-weight: $tabWeight
+      font-size: $tabSize
       color: white
       border-left: 3px solid
       border-top: 3px solid

--- a/src/components/question-wrapper.test.tsx
+++ b/src/components/question-wrapper.test.tsx
@@ -26,7 +26,7 @@ describe("QuestionWrapper component", () => {
     it("renders teacher tip tab", () => {
       const props = getProps({ authoredState });
       const wrapper = mount(<QuestionWrapper {...props}/>);
-      expect(wrapper.text()).toEqual(expect.stringContaining("Teacher Tips"));
+      expect(wrapper.text()).toEqual(expect.stringContaining("Teacher Tip"));
     });
 
     it("renders teacher tip once the tab is clicked", () => {

--- a/src/components/question-wrapper.tsx
+++ b/src/components/question-wrapper.tsx
@@ -138,7 +138,7 @@ export default class QuestionWrapper extends React.Component<IProps, IState> {
     return (
       <div className={css.teacherTip} onClick={this.toggleTeacherTip} data-cy="teacherTip">
         <span className={css.teacherTipIcon}><Icon/></span>
-        <span className={css.teacherTipLabel}>Teacher Tips</span>
+        <span className={css.teacherTipLabel}>Teacher Tip</span>
       </div>
     );
   }

--- a/src/components/window-shade-content.sass
+++ b/src/components/window-shade-content.sass
@@ -2,21 +2,30 @@
 
 .windowShadeContent
   margin: 20px
+  margin-top: 0
   font-family: $textFont
   font-weight: $textWeight
   font-size: $textSize
   line-height: $textHeight
-  margin-bottom: 12pt
+  p
+    width: 100%
+    margin-left: 10px
+    margin-top: 6px
+    margin-bottom: 6px
+    margin-right: 30px
+  h1, h2, h3, h4, h5
+    margin: 16px
+    margin-left: 10px
 
 .authorMarkdown
-  margin: 30px
-  margin-top: -15px
   table
     border-collapse: collapse
   th, td
     padding-left: 10px
     padding-right: 19px
     border: solid 1px $textBlack
+  hr
+    margin-top: 20px
 
   // *************************************************
   // Local Reset
@@ -74,8 +83,6 @@
     grid-column-end: 2
     grid-row-start: 1
     grid-row-end: 1
-    grid-column-gap: 0
-    width: 570px
     img
       width: 512px
       border: solid 2px
@@ -114,16 +121,20 @@
     grid-column-end: 3
     grid-row-start: 1
     grid-row-end: 2
+    width: 320px
+    .authorMarkdown
+      margin: 0
 
 .mediaContainerCenter
   display: flex
   flex-direction: column
   align-items: center
-  margin-left: 30px
-  margin-right: 30px
+  margin-left: 20px
+  margin-right: 20px
   margin-bottom: 20px
   .centerLayoutContent
     text-align: left
+    width: 880px
   .mediaWrapper
     img
       width: 880px

--- a/src/components/window-shade.sass
+++ b/src/components/window-shade.sass
@@ -1,10 +1,10 @@
 @import "themes.sass"
 
 .windowShade
-  min-width: 480px
+  width: 946px
+  max-width: 946px
+  min-width: 946px
   border-radius: $borderRadius
-  margin-top: 27px
-  margin-bottom: 27px
   border: $border-style $border-width
   
 .theoryAndBackground

--- a/src/demo.tsx
+++ b/src/demo.tsx
@@ -134,8 +134,10 @@ Give or take.
 `,
   // tslint:disable:no-trailing-whitespace
   content2: `
-Here is some **\`content2\`** text.  
-This bit of text contains  
+- - -
+
+Here is some **\`content2\`**  
+text.  This bit of text has  
 forced line-breaks.  
 `,
   // tslint:enable:no-trailing-whitespace
@@ -148,7 +150,7 @@ forced line-breaks.
 
 const authoredStateH = {
   windowShadeType: WindowShadeType.DiggingDeeper,
-  content: `
+  content2: `
 You just gotta love a **time-lapse** view of the night sky!
 
 Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium
@@ -162,7 +164,7 @@ adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et
 dolore magnam aliquam quaerat voluptatem.
 `,
   // tslint:disable:no-trailing-whitespace
-  content2: `
+  content: `
 ## A Poem
 
 There once was a writer from Nantucket,  


### PR DESCRIPTION
PT Stories:

* [Clean up styling](https://www.pivotaltracker.com/story/show/161789379)
* [There is too much space b/t intro text and Teacher Tip](https://www.pivotaltracker.com/story/show/162314007)
* And part of [Question Wrapper content needs style cleanup](https://www.pivotaltracker.com/story/show/162221246)

This work addresses several remaining styling issues with the WindowShade components. Issues **not addressed** in the PR have been documented in other PT stories: 1) issues related to the QuestionWrapper components have been documented in this separate PT Story [Question Wrapper content needs style cleanup](https://www.pivotaltracker.com/story/show/162221246); and, 2) a new PT story has been created for the a WindowShade issue, [WindowShade open animation](https://www.pivotaltracker.com/story/show/162398518)

This PR addresses:

1. Minor additions to demo page for testing some formatting/styling edge conditions.

1. Fixed the size of the window-shade components based on the UI design spec and adjusted widths an margins of the window-shade contents accordingly, in particular:

    * margin of the top of the content in the window-shade
    * inter-paragraph margin/spacing
    * heading margin/spacing (in Markdown authored components)
    * top spacing for horizontal rules (also within Markdown)
    * a few margin tweaks to the media content when the layout is `Layout.MediaCenter`
    * added some margin at the top of the authoring page
    * used font specified by the UI design spec for QuestionWrapper tab labels
    * changed "Teacher Tips" in QuestionWrapper tab labels to "Teacher Tip"