### PR TITLE
Removed the word "Help" form the sideTip tab label

### DIFF
--- a/src/components/side-tip.tsx
+++ b/src/components/side-tip.tsx
@@ -51,7 +51,7 @@ export default class SideTip extends React.Component<IProps, IState> {
     portalDom.style.maxHeight = "inherit";
     this.sidebarController = addSideBarMethod({
       handle: "",
-      titleBar: "Teacher Edition Help",
+      titleBar: "Teacher Edition",
       icon: sideBarIcon,
       titleBarColor: "#FDA61C",
       handleColor: "#DC8008",


### PR DESCRIPTION
[Remove word "Help" from sideTip tab](https://www.pivotaltracker.com/story/show/162428472)

As per conversation with PI, removed the word "Help" from the tab-title in the SideTip.