### PR TITLE
Window shade sizing

### DIFF
--- a/src/components/left-end-cap.sass
+++ b/src/components/left-end-cap.sass
@@ -3,6 +3,7 @@
 .leftEndCap
   position: relative
   width: 50px
+  min-width: 50px
   height: 50px
   border: $border-width $border-style
 
@@ -40,7 +41,7 @@
     fill: $orangeFrontIconColor
   &.diggingDeeper
     fill: $purpleFrontIconColor
-  
+
 .rearIcon
   z-index: 0
   fill-opacity: 0

--- a/src/components/window-shade-button.sass
+++ b/src/components/window-shade-button.sass
@@ -1,9 +1,10 @@
 @import "themes.sass"
-  
+
 .windowShadeButton
   top: -28px
   left: 25px
-  max-width: $windowShadeButtonWidth
+  width: $windowShadeButtonWidth
+  max-width: 92%
   height: 50px
   position: relative
   display: flex
@@ -20,7 +21,7 @@
     transform: translateX(-10px)
     transition: transform 0.25s
     transition-timing-function: ease-in-out
-  
+
 .theoryAndBackground
   color: $yellowButtonTextColor
   background-color: $yellowButtonBackgroundColor

--- a/src/components/window-shade.sass
+++ b/src/components/window-shade.sass
@@ -33,6 +33,7 @@
   border-bottom: 0
   border-radius: 0
   margin-right: 3px;
+  margin-bottom: 27px
   .content
     height: 0
     overflow: hidden

--- a/src/components/window-shade.sass
+++ b/src/components/window-shade.sass
@@ -28,12 +28,12 @@
 
 .windowShadeHidden
   height: 0
-  border-left: -3px
-  border-right: 0
   border-bottom: 0
   border-radius: 0
   margin-right: 3px;
   margin-bottom: 27px
+  border-left-color: transparent
+  border-right-color: transparent
   .content
     height: 0
     overflow: hidden

--- a/src/components/window-shade.sass
+++ b/src/components/window-shade.sass
@@ -1,12 +1,11 @@
 @import "themes.sass"
 
 .windowShade
-  width: 946px
+  width: 100%
   max-width: 946px
-  min-width: 946px
   border-radius: $borderRadius
   border: $border-style $border-width
-  
+
 .theoryAndBackground
   border-color: $yellowBorderColor
   background-color: $yellowContentBackgroundColor


### PR DESCRIPTION
* Prevent closed window shade buttons from overlapping each other (https://www.pivotaltracker.com/story/show/166196764)
* Prevent window shades from extending beyond width of page (https://www.pivotaltracker.com/story/show/166248940)
* Allow window shades to work in 60-40 layout. (Unasked for, but seemed worth adding)

See before and after images for both Precipitating Change (NextGen MW) and HAS themes.

Some compromises had to be made between the two themes, to balance preventing overlaps with making there be huge spaces between the window shades.

<img width="1000" alt="window-shades-old-new" src="https://user-images.githubusercontent.com/35721/58588607-05dd3380-822e-11e9-8e8f-543eb67f8eb3.png">
