### PR TITLE
Fit content around tall images

### DIFF
--- a/src/components/question-wrapper.sass
+++ b/src/components/question-wrapper.sass
@@ -57,15 +57,21 @@
     border-bottom-left-radius: 17px
     border-bottom-right-radius: 17px
     padding: 1px
+    display: grid
+    grid-template-columns: 100%
+    grid-template-rows: [main-content] auto [footer] auto
     position: relative
 
+    .originalContent
+      grid-column-start: 1
+      grid-row-start: main-content
+
     .overlay
-      position: absolute
+      grid-column-start: 1
+      grid-row-start: main-content
       pointer-events: none
       width: 100%
       height: 100%
-      top: 0
-      left: 0
       z-index: 1000
       border-radius: inherit
 
@@ -108,11 +114,12 @@
 
   .teacherTipImageOverlay
     width: 100%
-    position: absolute
-    top: 0
-    left: 0
+    grid-column-start: 1
+    grid-row-start: main-content
 
   .questionWrapperText
+    grid-column-start: 1
+    grid-row-start: footer
     font-family: Arial, Helvetica, sans-serif
     font-size: 16px
     line-height: 24px
@@ -131,6 +138,7 @@
       margin-bottom: 12pt
 
     &.stickyNote
+      grid-row-start: main-content
       position: absolute
       top: 100px
       margin: auto

--- a/src/components/question-wrapper.tsx
+++ b/src/components/question-wrapper.tsx
@@ -111,7 +111,7 @@ export default class QuestionWrapper extends React.Component<IProps, IState> {
         <div className={wrappedContentClass}>
           <div className={css.dotLeft}/>
           <div className={css.dotRight}/>
-          <div ref={this.wrappedEmbeddableDivContainer} />
+          <div className={css.originalContent} ref={this.wrappedEmbeddableDivContainer} />
           <div className={css.overlay} />
           { activeTab === "Correct" && this.renderCorrectOverlay() }
           { activeTab === "Distractors" && this.renderDistractorsOverlay() }


### PR DESCRIPTION
Tall images, as shown in https://authoring.staging.concord.org/activities/20130/pages/305347/?mode=teacher-edition, will now push down the teacher tip text and page content.

In a questionWrapper, we now use a grid layout and place the original content, the transparent overlay, and the optional image all in the same top cell. This has the effect of autosizing the top component to the tallest child, which pushes down the tip text and the rest of the page content.

(This was considered preferable to cropping the image, as the author might deliberately want an image that is taller than the interactive.)