### PR TITLE
Add top note option

### DIFF
--- a/src/components/authoring/question-wrapper/question-wrapper-form.tsx
+++ b/src/components/authoring/question-wrapper/question-wrapper-form.tsx
@@ -43,7 +43,8 @@ export default class QuestionWRapperForm extends React.Component<IProps, IState>
 
     const allLocations = [
       QuestionWrapperLocation.Bottom,
-      QuestionWrapperLocation.StickyNote
+      QuestionWrapperLocation.StickyNote,
+      QuestionWrapperLocation.Top
     ];
 
     return (

--- a/src/components/question-wrapper.sass
+++ b/src/components/question-wrapper.sass
@@ -59,7 +59,7 @@
     padding: 1px
     display: grid
     grid-template-columns: 100%
-    grid-template-rows: [main-content] auto [footer] auto
+    grid-template-rows: [header] auto [main-content] auto [footer] auto
     position: relative
 
     .originalContent
@@ -136,6 +136,10 @@
     p
       margin-top: 0px
       margin-bottom: 12pt
+
+    &.header
+      grid-row-start: header
+      border-radius: 0
 
     &.stickyNote
       grid-row-start: main-content

--- a/src/components/question-wrapper.tsx
+++ b/src/components/question-wrapper.tsx
@@ -84,6 +84,8 @@ export default class QuestionWrapper extends React.Component<IProps, IState> {
     let visibleTextClass = css.questionWrapperText;
     if (_location === QuestionWrapperLocation.StickyNote) {
       visibleTextClass += " " + css.stickyNote;
+    } else if (_location === QuestionWrapperLocation.Top) {
+      visibleTextClass += " " + css.header;
     }
 
     return (


### PR DESCRIPTION
This is a small addition to allow notes at the top of the wrapped content. It is based on top of #31 and simply adds a new header spot to the css grid.

It's a single commit, I can rebase once #31 is in.