### PR TITLE
167345456 exemplar color fix

### DIFF
--- a/src/components/question-wrapper.sass
+++ b/src/components/question-wrapper.sass
@@ -223,8 +223,6 @@
 
       div
         max-width: 400px
-        background-color: #1A97FF
-        border-color: #094F98
         color: #E4F1FF
         margin-top: 0
 

--- a/src/components/question-wrapper.sass
+++ b/src/components/question-wrapper.sass
@@ -224,6 +224,8 @@
       div
         max-width: 400px
         color: #E4F1FF
+        background-color: #1A97FF
+        border-color: #094F98
         margin-top: 0
 
         &:hover
@@ -244,3 +246,9 @@
           width: 44px
           display: inline-block
           border-top-left-radius: 22px
+      .exemplar
+        background: #2FE450
+        border-color: #128325
+        &:hover
+          background-color: #B8F7C3
+          color: #128325


### PR DESCRIPTION
Small PR to fix the colors of the exemplar tab when wrapping an interactive.  Not sure exactly who to ping on this PR, so it this code isn't familiar, please ignore.  Visual changes can be seen here (previously showed blue tab, should be green):
![image](https://user-images.githubusercontent.com/5126913/104360400-d85a0200-54c5-11eb-9e70-9a12f3f6e888.png)

