### PR TITLE
wrap QI MC question with proper tabs, send custom message when tab is clicked

### DIFF
--- a/src/components/plugin-app.tsx
+++ b/src/components/plugin-app.tsx
@@ -51,7 +51,7 @@ export default class PluginApp extends React.Component<IProps, IState> {
   }
 
   public renderQuestionWrapper() {
-    const { wrappedEmbeddableDiv, wrappedEmbeddableContext, authoredState } = this.props;
+    const { wrappedEmbeddableDiv, wrappedEmbeddableContext, authoredState, pluginContext } = this.props;
     const { questionWrapper } = authoredState;
     if (!wrappedEmbeddableDiv || !wrappedEmbeddableContext) {
       // tslint:disable-next-line:no-console
@@ -65,6 +65,10 @@ export default class PluginApp extends React.Component<IProps, IState> {
           wrappedEmbeddableDiv={wrappedEmbeddableDiv}
           wrappedEmbeddableContext={wrappedEmbeddableContext}
           logEvent={this.logEventMethod}
+          sendCustomMessage={pluginContext && pluginContext.wrappedEmbeddable &&
+            pluginContext.wrappedEmbeddable.sendCustomMessage
+            ? pluginContext.wrappedEmbeddable.sendCustomMessage
+            : undefined}
         />
       </div>
     );

--- a/src/components/question-wrapper.tsx
+++ b/src/components/question-wrapper.tsx
@@ -14,9 +14,15 @@ type TabName = "Correct" | "Distractors" | "TeacherTip" | "Exemplar";
 
 const LARA_MULTIPLE_CHOICE = "Embeddable::MultipleChoice";
 const LARA_INTERACTIVES = [ "MwInteractive", "ImageInteractive", "VideoInteractive" ];
+const MANAGED_INTERACTIVE = "ManagedInteractive";
 
 export const isMCQuestion = (wrappedEmbeddableContext: any) => {
-  return wrappedEmbeddableContext.type === LARA_MULTIPLE_CHOICE;
+  const authState = wrappedEmbeddableContext.authored_state
+                    ? JSON.parse(wrappedEmbeddableContext.authored_state)
+                    : undefined;
+  return wrappedEmbeddableContext.type === LARA_MULTIPLE_CHOICE
+         || (wrappedEmbeddableContext.type === MANAGED_INTERACTIVE && authState
+             && authState.questionType === "multiple_choice");
 };
 
 export const isInteractive = (wrappedEmbeddableContext: any) => {
@@ -28,6 +34,7 @@ interface IProps {
   wrappedEmbeddableDiv: HTMLElement;
   wrappedEmbeddableContext: any;
   logEvent: (logData: ILogEvent) => void;
+  sendCustomMessage?: (msg: any) => void;
 }
 
 interface IState {
@@ -235,7 +242,15 @@ export default class QuestionWrapper extends React.Component<IProps, IState> {
   private toggleExemplar = () => this.toggleTab("Exemplar");
 
   private toggleTab = (tabName: TabName) => {
+    const { sendCustomMessage } = this.props;
     const { activeTab } = this.state;
+    const messageType = tabName === "Correct" && activeTab !== "Correct"
+      ? "teacher-edition:showCorrectOverlay"
+      : tabName === "Distractors" && activeTab !== "Distractors"
+        ? "teacher-edition:showDistractorOverlay"
+        : "teacher-edition:hideOverlay";
+    const customMessage = { type: messageType, content: [] };
+    sendCustomMessage && sendCustomMessage(customMessage);
     const {tabOpened, tabClosed} = AnalyticsActionType;
     const action = (activeTab === tabName) ? tabClosed : tabOpened;
     const nextTab = (action === tabClosed) ? null : tabName;

--- a/src/components/question-wrapper.tsx
+++ b/src/components/question-wrapper.tsx
@@ -11,6 +11,9 @@ import * as css from "./question-wrapper.sass";
 import { ILogEvent, AnalyticsActionType } from "../utilities/analytics";
 
 type TabName = "Correct" | "Distractors" | "TeacherTip" | "Exemplar";
+const SHOW_CORRECT_OVERLAY_MESSAGE = "teacher-edition:showCorrectOverlay";
+const SHOW_DISTRACTOR_OVERLAY_MESSAGE = "teacher-edition:showDistractorOverlay";
+const HIDE_OVERLAY_MESSAGE = "teacher-edition:hideOverlay";
 
 const LARA_MULTIPLE_CHOICE = "Embeddable::MultipleChoice";
 const LARA_INTERACTIVES = [ "MwInteractive", "ImageInteractive", "VideoInteractive" ];
@@ -245,10 +248,10 @@ export default class QuestionWrapper extends React.Component<IProps, IState> {
     const { sendCustomMessage } = this.props;
     const { activeTab } = this.state;
     const messageType = tabName === "Correct" && activeTab !== "Correct"
-      ? "teacher-edition:showCorrectOverlay"
+      ? SHOW_CORRECT_OVERLAY_MESSAGE
       : tabName === "Distractors" && activeTab !== "Distractors"
-        ? "teacher-edition:showDistractorOverlay"
-        : "teacher-edition:hideOverlay";
+        ? SHOW_DISTRACTOR_OVERLAY_MESSAGE
+        : HIDE_OVERLAY_MESSAGE;
     const customMessage = { type: messageType, content: [] };
     sendCustomMessage && sendCustomMessage(customMessage);
     const {tabOpened, tabClosed} = AnalyticsActionType;


### PR DESCRIPTION
This PR wraps the new multiple choice questions with the correct and distractors tabs and sends a custom message when the tabs are clicked (the custom message is handled by the question interactive MC question and used to determine which overlay, if any, is shown).