### PR TITLE
Question wrappers not shown for some Library Interactive MC questions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,11 @@ cache:
 # cf. https://stackoverflow.com/a/52387639
 install:
 - travis_retry gem install s3_website -v 3.4.0
-- travis_retry pip install awscli --upgrade --user
 - travis_retry npm ci
 - travis_retry cypress install
+# the next command is to fix "SSLContext object is not available" error in awscli install
+- travis_retry pyenv global 3.6
+- travis_retry pip install awscli --upgrade --user
 script:
 - npm run build
 - npm run test:coverage -- --runInBand

--- a/src/components/question-wrapper.tsx
+++ b/src/components/question-wrapper.tsx
@@ -218,8 +218,15 @@ export default class QuestionWrapper extends React.Component<IProps, IState> {
     if (!isMCQuestion(question)) {
       return false;
     }
+    // Library Interactive MC questions (whose choices are defined within the question's 
+    // authored_state property instead of their own choices property) do not currently 
+    // support the correct answer indicator, so there is no point in enabling the Correct 
+    // tab if there is a correct answer but no correct answer explanation
+    const hasCorrectAnswer = typeof question.choices !== "undefined" 
+      ? question.choices.filter((c: any) => c.is_correct === true).length > 0
+      : false;
     // There's an explanation or at least one choice marked as correct.
-    return correctExplanation || question.choices.filter((c: any) => c.is_correct === true).length > 0;
+    return correctExplanation || hasCorrectAnswer;
   }
 
   private get showDistractorsTab() {

--- a/src/components/question-wrapper.tsx
+++ b/src/components/question-wrapper.tsx
@@ -218,11 +218,11 @@ export default class QuestionWrapper extends React.Component<IProps, IState> {
     if (!isMCQuestion(question)) {
       return false;
     }
-    // Library Interactive MC questions (whose choices are defined within the question's 
-    // authored_state property instead of their own choices property) do not currently 
-    // support the correct answer indicator, so there is no point in enabling the Correct 
+    // Library Interactive MC questions (whose choices are defined within the question's
+    // authored_state property instead of their own choices property) do not currently
+    // support the correct answer indicator, so there is no point in enabling the Correct
     // tab if there is a correct answer but no correct answer explanation
-    const hasCorrectAnswer = typeof question.choices !== "undefined" 
+    const hasCorrectAnswer = typeof question.choices !== "undefined"
       ? question.choices.filter((c: any) => c.is_correct === true).length > 0
       : false;
     // There's an explanation or at least one choice marked as correct.


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/177966731

[#177966731]

* Do not call `question.choices.filter()` if `question.choices` is undefined
* Add comment explaining why we're not checking for correct choices in Library Interactive multiple choice questions