### PR TITLE
Fix question wrappers not shown for some Library Interactive MC questions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,11 @@ cache:
 # cf. https://stackoverflow.com/a/52387639
 install:
 - travis_retry gem install s3_website -v 3.4.0
-- travis_retry pip install awscli --upgrade --user
 - travis_retry npm ci
 - travis_retry cypress install
+# the next command is to fix "SSLContext object is not available" error in awscli install
+- travis_retry pyenv global 3.6
+- travis_retry pip install awscli --upgrade --user
 script:
 - npm run build
 - npm run test:coverage -- --runInBand

--- a/src/components/authoring/question-wrapper/question-wrapper-form.tsx
+++ b/src/components/authoring/question-wrapper/question-wrapper-form.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import * as css from "./question-wrapper-form.sass";
 
 import { IAuthoredQuestionWrapper, QuestionWrapperLocation  } from "../../../types";
-import { isMCQuestion } from "../../question-wrapper";
 
 const QuestionWrapperLocationStrings = {
   [QuestionWrapperLocation.Bottom]: "Bottom",
@@ -52,7 +51,6 @@ export default class QuestionWRapperForm extends React.Component<IProps, IState>
 
     return (
       <div className={css.container}>
-        { isMCQuestion(wrappedEmbeddableContext) ?
         <div className={css.section}>
           <label> Correct Explanation (Markdown) </label>
           <br/>
@@ -60,9 +58,8 @@ export default class QuestionWRapperForm extends React.Component<IProps, IState>
             value={correctExplanation}
             onChange={this.updateCorrectExplaination}
           />
-        </div> : null }
+        </div>
 
-        { isMCQuestion(wrappedEmbeddableContext) ?
         <div className={css.section}>
           <label> Distractor Explanation (Markdown) </label>
           <br/>
@@ -70,7 +67,7 @@ export default class QuestionWRapperForm extends React.Component<IProps, IState>
             value={distractorsExplanation}
             onChange={this.updateDistractor}
           />
-        </div> : null }
+        </div>
 
         <div className={css.section}>
           <label> Teacher Tip (Markdown) </label>

--- a/src/components/question-wrapper.tsx
+++ b/src/components/question-wrapper.tsx
@@ -17,15 +17,9 @@ const HIDE_OVERLAY_MESSAGE = "teacher-edition:hideOverlay";
 
 const LARA_MULTIPLE_CHOICE = "Embeddable::MultipleChoice";
 const LARA_INTERACTIVES = [ "MwInteractive", "ImageInteractive", "VideoInteractive" ];
-const MANAGED_INTERACTIVE = "ManagedInteractive";
 
-export const isMCQuestion = (wrappedEmbeddableContext: any) => {
-  const authState = wrappedEmbeddableContext.authored_state
-                    ? JSON.parse(wrappedEmbeddableContext.authored_state)
-                    : undefined;
-  return wrappedEmbeddableContext.type === LARA_MULTIPLE_CHOICE
-         || (wrappedEmbeddableContext.type === MANAGED_INTERACTIVE && authState
-             && authState.questionType === "multiple_choice");
+export const isBuiltInMCQuestion = (wrappedEmbeddableContext: any) => {
+  return wrappedEmbeddableContext.type === LARA_MULTIPLE_CHOICE;
 };
 
 export const isInteractive = (wrappedEmbeddableContext: any) => {
@@ -60,7 +54,7 @@ export default class QuestionWrapper extends React.Component<IProps, IState> {
     const containerNode = this.wrappedEmbeddableDivContainer.current!;
     containerNode.appendChild(wrappedEmbeddableDiv);
 
-    if (isMCQuestion(wrappedEmbeddableContext)) {
+    if (isBuiltInMCQuestion(wrappedEmbeddableContext)) {
       // Find multiple choice answer inputs. Used later to position icons.
       this.answerInputs = this.findInputsInWrappedQuestion();
     }
@@ -115,9 +109,7 @@ export default class QuestionWrapper extends React.Component<IProps, IState> {
           }
           {
             this.showDistractorsTab &&
-            <div className={css.distractors} onClick={this.toggleDistractors} data-cy="distractors">
-              <XA/>Distractors
-            </div>
+            <div className={css.distractors} onClick={this.toggleDistractors} data-cy="distractors"><XA/>Distractors</div>
           }
           {
             this.showTeacherTipTab &&
@@ -161,7 +153,7 @@ export default class QuestionWrapper extends React.Component<IProps, IState> {
 
   private renderCorrectOverlay() {
     const { choices } = this.props.wrappedEmbeddableContext;
-    if (this.answerInputs.length === 0) {
+    if (this.answerInputs === undefined || this.answerInputs.length === 0) {
       return null;
     }
     return choices.map((choice: any, idx: number) =>
@@ -183,7 +175,7 @@ export default class QuestionWrapper extends React.Component<IProps, IState> {
 
   private renderDistractorsOverlay() {
     const { choices } = this.props.wrappedEmbeddableContext;
-    if (this.answerInputs.length === 0) {
+    if (this.answerInputs === undefined || this.answerInputs.length === 0) {
       return null;
     }
     return choices.map((choice: any, idx: number) =>
@@ -215,17 +207,13 @@ export default class QuestionWrapper extends React.Component<IProps, IState> {
   private get showCorrectTab() {
     const question = this.props.wrappedEmbeddableContext;
     const { correctExplanation } = this.props.authoredState;
-    if (!isMCQuestion(question)) {
-      return false;
-    }
     // There's an explanation or at least one choice marked as correct.
-    const choices = question.choices ? question.choices : JSON.parse(question.authored_state).choices;
-    return correctExplanation || choices.filter((c: any) => c.is_correct === true || c.correct === true).length > 0;
+    return correctExplanation || (question.choices && question.choices.filter((c: any) => c.is_correct === true).length > 0);
   }
 
   private get showDistractorsTab() {
     const { distractorsExplanation } = this.props.authoredState;
-    return distractorsExplanation && isMCQuestion(this.props.wrappedEmbeddableContext);
+    return distractorsExplanation && isBuiltInMCQuestion(this.props.wrappedEmbeddableContext);
   }
 
   private get showTeacherTipTab() {

--- a/src/components/question-wrapper.tsx
+++ b/src/components/question-wrapper.tsx
@@ -219,7 +219,8 @@ export default class QuestionWrapper extends React.Component<IProps, IState> {
       return false;
     }
     // There's an explanation or at least one choice marked as correct.
-    return correctExplanation || question.choices.filter((c: any) => c.is_correct === true).length > 0;
+    const choices = question.choices ? question.choices : JSON.parse(question.authored_state).choices;
+    return correctExplanation || choices.filter((c: any) => c.is_correct === true || c.correct === true).length > 0;
   }
 
   private get showDistractorsTab() {

--- a/src/components/question-wrapper.tsx
+++ b/src/components/question-wrapper.tsx
@@ -109,7 +109,7 @@ export default class QuestionWrapper extends React.Component<IProps, IState> {
           }
           {
             this.showDistractorsTab &&
-            <div className={css.distractors} onClick={this.toggleDistractors} data-cy="distractors"><XA/>Distractors</div>
+            this.renderDistractorToggle()
           }
           {
             this.showTeacherTipTab &&
@@ -147,6 +147,14 @@ export default class QuestionWrapper extends React.Component<IProps, IState> {
       <div className={css.teacherTip} onClick={this.toggleTeacherTip} data-cy="teacherTip">
         <span className={css.teacherTipIcon}><Icon/></span>
         <span className={css.teacherTipLabel}>Teacher Tip</span>
+      </div>
+    );
+  }
+
+  private renderDistractorToggle() {
+    return (
+      <div className={css.distractors} onClick={this.toggleDistractors} data-cy="distractors">
+        <XA/>Distractors
       </div>
     );
   }
@@ -207,8 +215,9 @@ export default class QuestionWrapper extends React.Component<IProps, IState> {
   private get showCorrectTab() {
     const question = this.props.wrappedEmbeddableContext;
     const { correctExplanation } = this.props.authoredState;
+    const hasChoices = question.choices && question.choices.filter((c: any) => c.is_correct === true).length > 0;
     // There's an explanation or at least one choice marked as correct.
-    return correctExplanation || (question.choices && question.choices.filter((c: any) => c.is_correct === true).length > 0);
+    return correctExplanation || hasChoices;
   }
 
   private get showDistractorsTab() {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/177966731

[#177966731]

This change ensures that library interactive multiple choice questions without a correct answer specified can have a question wrapper that doesn't have a Correct Explanation value. It also fixes a bug where the question wrapper form crashes if you set the Correction Explanation value to an empty string. 