### PR TITLE
Fix TE interactive wrappers displaying default text for correct tab.

### DIFF
--- a/src/components/authoring/inline-authoring-form.tsx
+++ b/src/components/authoring/inline-authoring-form.tsx
@@ -42,10 +42,10 @@ export const defaultSideTipProps: ISideTip = {
 /* tslint:enable max-line-length*/
 
 export const defaultQuestionWrapperProps: IAuthoredQuestionWrapper = {
-  correctExplanation: "correct",
-  distractorsExplanation: "distractor",
-  exemplar: "exemplar",
-  teacherTip: "teacherTip",
+  correctExplanation: "",
+  distractorsExplanation: "",
+  exemplar: "",
+  teacherTip: "",
   teacherTipImageOverlay: "",
   location: QuestionWrapperLocation.Bottom
 };

--- a/src/components/question-wrapper.tsx
+++ b/src/components/question-wrapper.tsx
@@ -222,7 +222,7 @@ export default class QuestionWrapper extends React.Component<IProps, IState> {
 
   private get showDistractorsTab() {
     const { distractorsExplanation } = this.props.authoredState;
-    return distractorsExplanation && isBuiltInMCQuestion(this.props.wrappedEmbeddableContext);
+    return distractorsExplanation;
   }
 
   private get showTeacherTipTab() {


### PR DESCRIPTION
"Related Content" in LARA activity form field. Is this used anywhere? On Learn -- related activities?

PT Story: https://www.pivotaltracker.com/story/show/178276526

[#178276526]

Removes unnecessary default text for correct, distractor, exemplar, and teacher tip values.