### PR TITLE
181717687 fix rendering of markdown component, re-add manifest.json

### DIFF
--- a/src/components/question-wrapper.tsx
+++ b/src/components/question-wrapper.tsx
@@ -62,6 +62,29 @@ export default class QuestionWrapper extends React.Component<IProps, IState> {
     this.logAction(AnalyticsActionType.loaded);
   }
 
+  // NP: 2022-06-02 - A bit hacky. Jest doesn't thing Markdown is a react
+  // component, so without this guard, jest fails tests. I can't figure out
+  // if there is something weird about how the Markdown component exports itself
+  // or why jest module loading wouldn't be the same as typescript module loading.
+  public renderMarkdown(visibleText: string, visibleTextClass: string) {
+    if (Markdown !== undefined) {
+      return (
+        <div className={visibleTextClass}>
+            <Markdown className={css.authorMarkdown}>
+              { visibleText }
+            </Markdown>
+        </div>
+      );
+    }
+    return (
+      <div className={visibleTextClass}>
+          <div className={css.authorMarkdown}>
+            { visibleText }
+          </div>
+      </div>
+    )
+  }
+
   public render() {
     const { activeTab } = this.state;
     const { authoredState, wrappedEmbeddableContext } = this.props;
@@ -130,12 +153,7 @@ export default class QuestionWrapper extends React.Component<IProps, IState> {
           { activeTab === "Distractors" && this.renderDistractorsOverlay() }
           { activeTab === "TeacherTip" && this.renderImageOverlay() }
           {
-            visibleText &&
-            <div className={visibleTextClass}>
-              <Markdown className={css.authorMarkdown}>
-                { visibleText }
-              </Markdown>
-            </div>
+            visibleText && this.renderMarkdown(visibleText, visibleTextClass)
           }
         </div>
       </div>

--- a/src/components/question-wrapper.tsx
+++ b/src/components/question-wrapper.tsx
@@ -82,7 +82,7 @@ export default class QuestionWrapper extends React.Component<IProps, IState> {
             { visibleText }
           </div>
       </div>
-    )
+    );
   }
 
   public render() {

--- a/src/components/question-wrapper.tsx
+++ b/src/components/question-wrapper.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as Markdown from "markdown-to-jsx";
+import Markdown from "markdown-to-jsx";
 import { IAuthoredQuestionWrapper, TeacherTipType, QuestionWrapperLocation } from "../types";
 import CheckA from "../icons/check_A.svg";
 import XA from "../icons/x_A.svg";

--- a/src/components/side-tip.tsx
+++ b/src/components/side-tip.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import sideBarIcon from "../side-bar-icon";
-import * as Markdown from "markdown-to-jsx";
+import Markdown from "markdown-to-jsx";
 import css from "./side-tip.sass";
 import { ISideTip, TeacherTipType } from "../types";
 import * as PluginAPI from "@concord-consortium/lara-plugin-api";

--- a/src/components/window-shade-content.tsx
+++ b/src/components/window-shade-content.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as Markdown from "markdown-to-jsx";
+import Markdown from "markdown-to-jsx";
 
 import css from "./window-shade-content.sass";
 import { IWindowShadeConfiguration } from "../config/ui-configurations";

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,3 +1,2 @@
 // So we can import CSS modules.
 declare module "*.sass";
-declare module "markdown-to-jsx";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,7 +85,7 @@ module.exports = (env, argv) => {
       }),
       new CopyPlugin({
         patterns: [
-          { from: './src/public/*.json', to: './' }
+          { from: './src/public/manifest.json', to: 'manifest.json' }
         ]})
     ],
     externals: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,8 @@ module.exports = (env, argv) => {
     devtool: devMode ? 'eval-cheap-module-source-map' : 'source-map',
     output: {
       path: path.resolve(__dirname, 'dist'),
-      filename: '[name].js'
+      filename: '[name].js',
+      publicPath: '/'
     },
     module: {
       rules: [
@@ -63,7 +64,13 @@ module.exports = (env, argv) => {
       },
       headers: {
         'Access-Control-Allow-Origin': '*'
-      }
+      },
+      devMiddleware: {
+        index: true,
+        serverSideRender: true,
+        publicPath: '/',
+        writeToDisk: true,
+      },
     },
     plugins: [
       new HtmlWebpackPlugin({
@@ -75,8 +82,11 @@ module.exports = (env, argv) => {
         template: './src/public/demo.html',
         filename: 'demo.html',
         chunks: ['demo']
-      })
-      // new CleanWebpackPlugin()
+      }),
+      new CopyPlugin({
+        patterns: [
+          { from: './src/public/*.json', to: './' }
+        ]})
     ],
     externals: {
       'react': 'React',


### PR DESCRIPTION

- Copies `manifest.json` to `dist` folder when building
- In dev mode, copies the manifest.json to public folder.
- fix Markdown component imports