### PR TITLE
Improve styling of TE edit interface

### DIFF
--- a/src/components/_fonts.sass
+++ b/src/components/_fonts.sass
@@ -1,0 +1,24 @@
+@mixin font-import()
+  @font-face
+    font-family: 'Lato-Light'
+    font-style: normal
+    font-weight: 100
+    src: local('Lato Light'), local('Lato-Light'), url(//fonts.googleapis.com/css?family=Lato:100) format('woff')
+
+  @font-face
+    font-family: 'Lato-Regular'
+    font-style: normal
+    font-weight: 400
+    src: local('Lato Regular'), local('Lato-Regular'), url(//themes.googleusercontent.com/static/fonts/lato/v6/qIIYRU-oROkIk8vfvxw6QvesZW2xOQ-xsNqO47m55DA.woff) format('woff')
+
+  @font-face
+    font-family: 'Lato-Bold'
+    font-style: normal
+    font-weight: 700
+    src: local('Lato Bold'), local('Lato-Bold'), url(//themes.googleusercontent.com/static/fonts/lato/v6/qdgUG4U09HnJwhYI-uK18wLUuEpTyoUstqEm5AMlJo4.woff) format('woff')
+
+@include font-import
+
+$fontFamilyBold: Lato-Bold, helvetica, verdana, sans-serif
+$fontFamilyDefault: Lato-Regular, helvetica, verdana, sans-serif
+$fontFamilyLight: Lato-Light, helvetica, verdana, sans-serif

--- a/src/components/_themes.sass
+++ b/src/components/_themes.sass
@@ -1,4 +1,5 @@
 @import "_color-themes.sass"
+@import "_fonts.sass"
 
 $radius: 25px
 $endCapRadius: 28px
@@ -8,22 +9,22 @@ $padding: 45px 30px 28px 30px
 $borderRadius: 0px 0px $radius $radius
 $windowShadeButtonWidth: 400px
 
-$bannerFont: Roboto, sans-serif
+$bannerFont: $fontFamilyDefault
 $bannerWeight: bold
 $bannerSize: 15pt
 
-$textFont:  Arial, sans-serif
-$textWeight: normal
+$textFont:  $fontFamilyDefault
+$textWeight: 400
 $textSize: 12pt
 $textHeight: 18pt
 
-$captionFont: Arial, sans-serif
-$captionWeight: normal
+$captionFont: $fontFamilyDefault
+$captionWeight: 400
 $captionSize: 10.5pt
 $captionHeight: 12.75pt
 
-$tabFont: Roboto, sans-serif
-$tabWeight: bold
+$tabFont: $fontFamilyBold
+$tabWeight: 700
 $tabSize: 13.5pt
 
 $stickyNoteWidth: 400px

--- a/src/components/authoring/authoring-app.sass
+++ b/src/components/authoring/authoring-app.sass
@@ -10,7 +10,7 @@
 .preview
   grid-column: 2
   grid-row: 1
-  margin: 0.25em
+  margin: 0
   min-width: 500px
 
 .authoringFormContainer
@@ -20,8 +20,7 @@
   overflow: scroll
 
 .form
-  margin: 0.25em
-  border: 1px solid gray
+  margin: 0
 
 .json
   grid-column: 1
@@ -41,11 +40,9 @@
     padding-left: 10px
     font-family: sans-serif
     font-size: 16pt
-    background-color: hsl(200,40%,95%)
 
 .inlineAuthoringContainer
-  margin: 0.25em
-  border: 1px solid gray
+  margin: 0
 
 .inlineFormButtons
   display: flex
@@ -53,4 +50,14 @@
   font-size: 1.2em
 
   button
-    margin: 5px
+    background: #e2f4f8
+    border: solid 1.5px #979797
+    border-radius: 4px
+    color: #3f3f3f
+    cursor: pointer
+    display: flex
+    font-size: 16px
+    font-weight: 700
+    margin: 0 0 0 10px
+    padding: 5px 10px
+    position: relative

--- a/src/components/authoring/authoring-app.sass
+++ b/src/components/authoring/authoring-app.sass
@@ -8,15 +8,31 @@
   grid-row: 1
 
 .preview
+  background: white
   grid-column: 2
   grid-row: 1
   margin: 0
   min-width: 500px
+  position: sticky
+  top: 0
+  z-index: 5
+
+  // The :before rule set below prevents content that scrolls
+  // below the .preview div from showing through the gap 
+  // between it and the top of the authoring form dialog.
+  &:before
+    background: white
+    content: ""
+    display: block
+    height: 10px
+    position: absolute
+    top: -10px
+    width: 100%
 
 .authoringFormContainer
   grid-column: 2
   grid-row: 2 / 3
-  max-height: 50vh
+  max-height: 100%
   overflow: scroll
 
 .form
@@ -43,13 +59,23 @@
 
 .inlineAuthoringContainer
   margin: 0
+  padding-bottom: 50px
+  position: relative
 
 .inlineFormButtons
+  background: white
+  border-top: solid 1px #979797
+  bottom: 20px
   display: flex
-  justify-content: flex-end
   font-size: 1.2em
+  left: 1px
+  justify-content: flex-end
+  padding: 5px
+  position: fixed
+  width: calc(100% - 12px)
+  z-index: 10
 
-  button
+  .inlineFormButton
     background: #e2f4f8
     border: solid 1.5px #979797
     border-radius: 4px
@@ -58,6 +84,26 @@
     display: flex
     font-size: 16px
     font-weight: 700
-    margin: 0 0 0 10px
+    margin: 0 0 0 10px !important
     padding: 5px 10px
     position: relative
+
+    &:hover
+      background: #93d5e4
+    &:active
+      background: #0592af
+      color: white
+      .svgIcon
+        fill: white
+
+    .svgIcon
+      align-self: center
+      display: inline-block
+      fill: #0592af
+      margin: 0 3px 0 0
+      padding: 0
+      vertical-align: top
+    
+    .lineAdjust
+      height: 17px
+      line-height: 17px

--- a/src/components/authoring/inline-authoring-form.tsx
+++ b/src/components/authoring/inline-authoring-form.tsx
@@ -15,6 +15,7 @@ import {
   WindowShadeType, QuestionWrapperLocation
 } from "../../types";
 import { ILogEvent } from "../../utilities/analytics";
+import { getFormButtonsConfiguration } from "../../config/ui-configurations";
 
 export const defaultWindowShadeProps: IWindowShade = {
   windowShadeType: WindowShadeType.TheoryAndBackground,
@@ -72,6 +73,8 @@ export default class InlineAuthoringForm extends React.Component<IProps, IState>
     const showWindowShade =  tipType === TeacherTipType.WindowShade;
     const showQuestionWrapper =  tipType === TeacherTipType.QuestionWrapper;
     const showSideTip =  tipType === TeacherTipType.SideTip;
+    const cancelButtonConfig = getFormButtonsConfiguration("cancelButton");
+    const saveButtonConfig = getFormButtonsConfiguration("saveButton");
     return (
       <div className={css.inlineAuthoringContainer}>
         <div className={css.preview}>
@@ -98,6 +101,8 @@ export default class InlineAuthoringForm extends React.Component<IProps, IState>
             />
           }
           <br/>
+        </div>
+        <div className={css.authoringFormContainer}>
           {
           showWindowShade &&
           <WindowShadeForm
@@ -124,8 +129,18 @@ export default class InlineAuthoringForm extends React.Component<IProps, IState>
           }
         </div>
         <div className={css.inlineFormButtons + " submit-container"}>
-          <button onClick={this.saveAuthoredState} className="embeddable-save">Save</button>
-          <button className="close">Cancel</button>
+          <button className={css.inlineFormButton}>
+            <cancelButtonConfig.Icon className={css.svgIcon} />
+            <span className={css.lineAdjust}>
+              Cancel
+            </span>
+          </button>
+          <button onClick={this.saveAuthoredState} className={css.inlineFormButton}>
+            <saveButtonConfig.Icon className={css.svgIcon} />
+            <span className={css.lineAdjust}>
+              Save
+            </span>
+          </button>
         </div>
       </div>
     );

--- a/src/components/authoring/question-wrapper/question-wrapper-form.sass
+++ b/src/components/authoring/question-wrapper/question-wrapper-form.sass
@@ -1,4 +1,3 @@
-
 @import "../../_fonts.sass"
 
 .container
@@ -7,11 +6,15 @@
   flex-direction: column
   overflow: auto
   *
-    margin: 5px 10px 0
+    margin: 5px
   label
     font-family: $fontFamilyBold
     font-size: 16px
     font-weight: 700
+  .inputType
+    color: #777
+    font-size: 12px
+    margin: 0
 
 .section
   width: calc(100% - 30px)

--- a/src/components/authoring/question-wrapper/question-wrapper-form.sass
+++ b/src/components/authoring/question-wrapper/question-wrapper-form.sass
@@ -1,24 +1,17 @@
+
+@import "../../_fonts.sass"
+
 .container
-  font-family: "Roboto", sans-serif
-  font-size: 12pt
+  align-items: flex-start
   display: flex
   flex-direction: column
-  align-items: flex-start
   overflow: auto
-  background: hsl(50, 10%, 95%)
-  border-radius: 0.5em
   *
-    margin: 0.5em
+    margin: 5px 10px 0
+  label
+    font-family: $fontFamilyBold
+    font-size: 16px
+    font-weight: 700
 
 .section
-  width: 93%
-
-  textArea
-    padding: 1em
-    height: 200px
-    width: 100%
-    font-family: monospace
-
-  input[type="text"]
-    padding: 1em
-    width: 100%
+  width: calc(100% - 30px)

--- a/src/components/authoring/question-wrapper/question-wrapper-form.tsx
+++ b/src/components/authoring/question-wrapper/question-wrapper-form.tsx
@@ -87,7 +87,7 @@ export default class QuestionWRapperForm extends React.Component<IProps, IState>
         </div>
 
         <div className={css.section}>
-          <label> Exemplar </label>
+          <label> Exemplar (Markdown) </label>
           <br/>
           <textarea
             value={exemplar}

--- a/src/components/authoring/question-wrapper/question-wrapper-form.tsx
+++ b/src/components/authoring/question-wrapper/question-wrapper-form.tsx
@@ -51,7 +51,7 @@ export default class QuestionWRapperForm extends React.Component<IProps, IState>
     return (
       <div className={css.container}>
         <div className={css.section}>
-          <label> Correct Explanation (Markdown) </label>
+          <label> Correct Explanation <span className={css.inputType}>(markdown)</span> </label>
           <br/>
           <textarea
             value={correctExplanation}
@@ -60,7 +60,7 @@ export default class QuestionWRapperForm extends React.Component<IProps, IState>
         </div>
 
         <div className={css.section}>
-          <label> Distractor Explanation (Markdown) </label>
+          <label> Distractor Explanation <span className={css.inputType}>(markdown)</span> </label>
           <br/>
           <textarea
             value={distractorsExplanation}
@@ -69,7 +69,7 @@ export default class QuestionWRapperForm extends React.Component<IProps, IState>
         </div>
 
         <div className={css.section}>
-          <label> Teacher Tip (Markdown) </label>
+          <label> Teacher Tip <span className={css.inputType}>(markdown)</span> </label>
           <br/>
           <textarea
             value={teacherTip}
@@ -78,7 +78,7 @@ export default class QuestionWRapperForm extends React.Component<IProps, IState>
         </div>
 
         <div className={css.section}>
-          <label> Teacher Tip Image Overlay (Markdown) </label>
+          <label> Teacher Tip Image Overlay <span className={css.inputType}>(markdown)</span> </label>
           <br/>
           <input type="text"
             value={teacherTipImageOverlay}
@@ -87,7 +87,7 @@ export default class QuestionWRapperForm extends React.Component<IProps, IState>
         </div>
 
         <div className={css.section}>
-          <label> Exemplar (Markdown) </label>
+          <label> Exemplar <span className={css.inputType}>(markdown)</span> </label>
           <br/>
           <textarea
             value={exemplar}

--- a/src/components/authoring/window-shade/window-shade-form.sass
+++ b/src/components/authoring/window-shade/window-shade-form.sass
@@ -1,25 +1,30 @@
+@import "../../_fonts.sass"
+
 .container
-  font-family: "Roboto", sans-serif
-  font-size: 12pt
+  align-items: flex-start
   display: flex
   flex-direction: column
-  align-items: flex-start
   overflow: auto
-  background: hsl(50, 10%, 95%)
-  border-radius: 0.5em
   *
-    margin: 0.5em
+    margin: 5px
+  label
+    font-family: $fontFamilyBold
+    font-size: 16px
+    font-weight: 700
+  .inputType
+    color: #777
+    font-size: 12px
+    margin: 0
 
 .section
-  width: 93%
+  width: calc(100% - 30px)
 
   select
     width: 300px
 
   textArea
-    padding: 1em
+    font-family: $fontFamilyDefault
     width: 100%
-    font-family: monospace
     &.caption
       height: 60px
 
@@ -27,5 +32,5 @@
     width: 100%
 
   .note
-    font-size: 0.8em
+    font-size: 14px
     font-style: italic

--- a/src/components/authoring/window-shade/window-shade-form.tsx
+++ b/src/components/authoring/window-shade/window-shade-form.tsx
@@ -137,7 +137,7 @@ export default class WindowShadeForm extends React.Component<IProps, IState> {
             onChange={this.updateMediaURL}/>
         </div>
         <div className={css.section}>
-          <label> Media Caption (Markdown) </label>
+          <label> Media Caption <span className={css.inputType}>(markdown)</span> </label>
           <br/>
           <textarea
             className={css.caption}
@@ -145,14 +145,14 @@ export default class WindowShadeForm extends React.Component<IProps, IState> {
             onChange={this.updateMediaCaption}/>
         </div>
         <div className={css.section}>
-          <label> Content (Markdown) </label>
+          <label> Content <span className={css.inputType}>(markdown)</span> </label>
           <br/>
           <textarea
             value={content}
             onChange={this.updateContent}/>
         </div>
         <div className={css.section}>
-          <label> Content-2 (Markdown) </label>
+          <label> Content-2 <span className={css.inputType}>(markdown)</span> </label>
           <br/>
           <p className={css.note}>
             Note: Content-2 is rendered after Content except when you use the "mediaCenter" layout,

--- a/src/components/left-end-cap.sass
+++ b/src/components/left-end-cap.sass
@@ -5,6 +5,7 @@
   width: 50px
   min-width: 50px
   height: 50px
+  min-height: 50px
   border: $border-width $border-style
 
 .theoryAndBackground

--- a/src/components/question-wrapper.sass
+++ b/src/components/question-wrapper.sass
@@ -2,7 +2,7 @@
 
 .questionWrapper
   .headers
-    height: 50px
+    height: 50px !important
     overflow: hidden
     display: flex
 
@@ -20,7 +20,7 @@
       border-top-left-radius: 24px
       border-top-right-radius: 24px
       display: inline-block
-      height: 50px
+      height: 50px !important
       text-align: left
       cursor: pointer
       vertical-align: top
@@ -82,6 +82,7 @@
     display: grid
     grid-template-columns: 100%
     grid-template-rows: [header] auto [main-content] auto [footer] auto
+    overflow: hidden
     position: relative
 
     .originalContent

--- a/src/config/ui-configurations.tsx
+++ b/src/config/ui-configurations.tsx
@@ -14,6 +14,12 @@ import FrameA from "../icons/frame_A.svg";
 import FrameB from "../icons/frame_B.svg";
 import ToolsA from "../icons/tools_A.svg";
 import ToolsB from "../icons/tools_B.svg";
+import Cancel from "../icons/cancel.svg";
+import Save from "../icons/save.svg";
+
+export interface IFormButtonsConfiguration {
+  Icon: SvgrComponent;
+}
 
 export interface IWindowShadeConfiguration {
   FrontIcon: SvgrComponent;
@@ -21,6 +27,15 @@ export interface IWindowShadeConfiguration {
   label: string;
   styleClassName: string;
 }
+
+export const FormButtonsConfiguration: {[index: string]: IFormButtonsConfiguration} = {
+  cancelButton: {
+    Icon: Cancel
+  },
+  saveButton: {
+    Icon: Save
+  },
+};
 
 export const WindowShadeConfigurations: {[index: string]: IWindowShadeConfiguration} = {
   teacherTip: {
@@ -71,6 +86,10 @@ export const WindowShadeConfigurations: {[index: string]: IWindowShadeConfigurat
     label: "Offline Activity",
     styleClassName: "offline",
   }
+};
+
+export const getFormButtonsConfiguration = (key: string) => {
+  return FormButtonsConfiguration[key];
 };
 
 export const getContentConfiguration = (key: string) => {

--- a/src/icons/cancel.svg
+++ b/src/icons/cancel.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg aria-hidden="true" className="icon" fill="white" focusable="false"  height="12" width="12" role="img" viewBox="0 0 8.38 8.39" xmlns="http://www.w3.org/2000/svg">
+  <polygon points="8.38 2.02 6.36 0 4.18 2.17 2.02 0.01 0 2.04 2.16 4.2 0 6.35 2.02 8.38 4.18 6.22 6.36 8.39 8.38 6.37 6.21 4.2 8.38 2.02"/>
+</svg>

--- a/src/icons/save.svg
+++ b/src/icons/save.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg aria-hidden="true" className="icon" fill="white" focusable="false" height="16" width="16" role="img" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+  <g>
+    <path d="M15.173 2H4c-1.101 0-2 .9-2 2v12c0 1.1.899 2 2 2h12c1.101 0 2-.9 2-2V5.127L15.173 2zM14 8c0 .549-.45 1-1 1H7c-.55 0-1-.451-1-1V3h8v5zm-1-4h-2v4h2V4z"/>
+  </g>
+</svg>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,7 +45,7 @@ module.exports = (env, argv) => {
 
               options: {
                 modules: {
-                  mode: "local",
+                  mode: 'local',
                   localIdentName: '[name]--[local]--TETipsPluginV1'
                 },
                 sourceMap: true,
@@ -103,6 +103,6 @@ module.exports = (env, argv) => {
         'react-dom': '@hot-loader/react-dom'
       }
     }
-  }
+  };
 };
 


### PR DESCRIPTION
PT Stories:

https://www.pivotaltracker.com/story/show/182346533
https://www.pivotaltracker.com/story/show/182276735

[#182346533]
[#182276735]

These changes update the look and feel of the window shade and question wrapper authoring forms so that they better fit the LARA 2 UI. In addition, the TE element preview in the authoring forms is made sticky so that it is always visible while making edits.