### PR TITLE
Fix issues with mediaCenter layout in TE window shades

### DIFF
--- a/src/components/authoring/authoring-app.sass
+++ b/src/components/authoring/authoring-app.sass
@@ -20,6 +20,8 @@
   // The :before rule set below prevents content that scrolls
   // below the .preview div from showing through the gap 
   // between it and the top of the authoring form dialog.
+  // This will become unnecessary once the preview is moved 
+  // to a column to the right of the authoring form.
   &:before
     background: white
     content: ""
@@ -28,6 +30,22 @@
     position: absolute
     top: -10px
     width: 100%
+
+// This is a temporary solution to ensure that media in 
+// window shade tips doesn't make the authoring form 
+// unusable by taking over the entire form modal. This 
+// will become unnecessary once the preview is moved to a 
+// column to the right of the authoring form.
+div[class*="preview"]
+  div[class*="mediaContainerCenter"]
+    div[class*="mediaWrapper"]
+      img, video
+        max-height: 250px
+        width: auto
+      &:after
+        content: "NOTE: Any media in this preview will appear scaled down for this authoring view. To see it actual size, preview in Activity Player."
+        font-size: 14px
+        font-style: italic
 
 .authoringFormContainer
   grid-column: 2

--- a/src/components/window-shade-content.sass
+++ b/src/components/window-shade-content.sass
@@ -191,18 +191,18 @@
       margin: 0
 
 .mediaContainerCenter
-  display: flex
-  flex-direction: column
-  align-items: center
   margin-left: 20px
   margin-right: 20px
   margin-bottom: 20px
+  text-align: center
   .centerLayoutContent
+    height: auto
     text-align: left
-    width: 880px
+    width: 100%
   .mediaWrapper
     img
-      width: 880px
+      height: auto
+      width: 100%
       border: solid 2px
       &.theoryAndBackground
         border-color: $deepYellow
@@ -221,7 +221,8 @@
       &.offline
         border-color: $green-dark-3
     video
-      width: 768px
+      height: auto
+      width: 100%
       border: solid 2px
       &.theoryAndBackground
         border-color: $deepYellow
@@ -240,7 +241,7 @@
       &.offline
         border-color: $green-dark-3
     .mediaCaption
-      width: 750px
+      width: 100%
       text-align: center
       font-family: $captionFont
       font-weight: $captionWeight


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/182597761

[#182597761]

Currently, media in a TE window shade that uses the `mediaCenter` layout option can extend beyond the boundaries of its container in both runtime and authoring. It can make the authoring form unusable because the preview in the authoring form can take over the height of the authoring modal. These changes ensure that the media won't ever be larger than its container, and scales the media in the context of authoring. The latter is a temporary fix until we move the preview into a separate column in the authoring form.