### PR TITLE
Fix issue with mediaCenter layout in window shades

### DIFF
--- a/src/components/authoring/authoring-app.sass
+++ b/src/components/authoring/authoring-app.sass
@@ -40,7 +40,9 @@ div[class*="preview"]
   div[class*="mediaContainerCenter"]
     div[class*="mediaWrapper"]
       img, video
+        height: auto
         max-height: 250px
+        max-width: 100%
         width: auto
       &:after
         content: "NOTE: Any media in this preview will appear scaled down for this authoring view. To see it actual size, preview in Activity Player."


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/182597761

[#182597761]

Previous changes for the mediaCenter problems introduced a small layout bug where an image or video could slightly extend beyond its containing column in the authoring view when the window shade appeared in a narrow column. This change fixes that.