### PR TITLE
Add vertical scrollbar to TE edit form

### DIFF
--- a/src/components/authoring/authoring-app.sass
+++ b/src/components/authoring/authoring-app.sass
@@ -13,23 +13,8 @@
   grid-row: 1
   margin: 0
   min-width: 500px
-  position: sticky
   top: 0
   z-index: 5
-
-  // The :before rule set below prevents content that scrolls
-  // below the .preview div from showing through the gap 
-  // between it and the top of the authoring form dialog.
-  // This will become unnecessary once the preview is moved 
-  // to a column to the right of the authoring form.
-  &:before
-    background: white
-    content: ""
-    display: block
-    height: 10px
-    position: absolute
-    top: -10px
-    width: 100%
 
 // This is a temporary solution to ensure that media in 
 // window shade tips doesn't make the authoring form 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/183407024

[#183407024]

The required scrollbar was already present. The issue was the preview section of the form was fixed in place. So when it contained a lot of content, the form fields would scroll behind the preview and weren't visible.

These changes make it so the preview will scroll out of view when the author scrolls down the edit form. This is a temporary solution until we can devote more time to putting the preview in a separate column. See https://www.pivotaltracker.com/story/show/182732380